### PR TITLE
Update bus and begin PPU implemention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Debug/
 *.user
 
 *.txt
+
+roms/

--- a/dmg-emu.vcxproj
+++ b/dmg-emu.vcxproj
@@ -19,11 +19,15 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\Cartridge.cpp" />
+    <ClCompile Include="src\PPU.cpp" />
     <ClCompile Include="src\Bus.cpp" />
     <ClCompile Include="src\CPU.cpp" />
     <ClCompile Include="src\main.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\Cartridge.h" />
+    <ClInclude Include="src\PPU.h" />
     <ClInclude Include="src\Bus.h" />
     <ClInclude Include="src\CPU.h" />
     <ClInclude Include="src\olcPixelGameEngine.h" />

--- a/dmg-emu.vcxproj.filters
+++ b/dmg-emu.vcxproj.filters
@@ -24,6 +24,12 @@
     <ClCompile Include="src\main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Cartridge.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\PPU.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Bus.h">
@@ -33,6 +39,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\olcPixelGameEngine.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Cartridge.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\PPU.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Bus.cpp
+++ b/src/Bus.cpp
@@ -51,6 +51,12 @@ void Bus::write(uint16_t addr, uint8_t data) {
 	}
 	else if (addr >= 0xFF00 && addr <= 0xFF7F) {
 		// io registers
+		
+		// Set joypad input to detect no button presses for now
+		if (addr == 0xFF00) {
+			data |= 0x0F;
+		}
+
 		ioRegisters[addr - 0xFF00] = data;
 	}
 	else if (addr >= 0xFF80 && addr <= 0xFFFE) {

--- a/src/Bus.cpp
+++ b/src/Bus.cpp
@@ -2,9 +2,9 @@
 
 Bus::Bus() {
 	// Clear RAM
-	for (auto& i : ram) {
+	/*for (auto& i : ram) {
 		i = 0x00;
-	}
+	}*/
 
 	// Connect CPU to bus
 	cpu.connectBus(this);
@@ -14,17 +14,93 @@ Bus::~Bus() {
 }
 
 void Bus::write(uint16_t addr, uint8_t data) {
-	// 8KB is 2^13 bytes, so need 13 bits to address it
-	// Max address is 16 * 16 * 16 * 2
-	if (addr >= 0x0000 && addr <= 0xFFFF) {
-		ram[addr] = data;
+	if (addr >= 0x0000 && addr <= 0x7FFF) {
+		// cartridge
+		rom[addr] = data;
+	}
+	else if (addr >= 0x8000 && addr <= 0x9FFF) {
+		// video ram
+		vram[addr - 0x8000] = data;
+	}
+	else if (addr >= 0xA000 && addr <= 0xBFFF) {
+		// external ram
+		externalRam[addr - 0xA000] = data;
+	}
+	else if (addr >= 0xC000 && addr <= 0xDFFF) {
+		// wram
+		wram[addr - 0xC000] = data;
+	}
+	else if (addr >= 0xE000 && addr <= 0xFDFF) {
+		// echo ram, prohibited
+		return;
+	}
+	else if (addr >= 0xFE00 && addr <= 0xFE9F) {
+		// oam ram
+		oam[addr - 0xFE00] = data;
+	}
+	else if (addr >= 0xFEA0 && addr <= 0xFEFF) {
+		// unusable
+		return;
+	}
+	else if (addr >= 0xFF00 && addr <= 0xFF7F) {
+		// io registers
+		ioRegisters[addr - 0xFF00] = data;
+	}
+	else if (addr >= 0xFF80 && addr <= 0xFFFE) {
+		// hram
+		hram[addr - 0xFF80] = data;
+	}
+	else if (addr == 0xFFFF) {
+		// ie register
+		ieRegister[addr - 0xFFFF] = data;
 	}
 }
 
 uint8_t Bus::read(uint16_t addr) {
-	if (addr >= 0x0000 && addr <= 0xFFFF) {
-		return ram[addr];
+	if (addr >= 0x0000 && addr <= 0x7FFF) {
+		// cartridge, fixed bank
+		return rom[addr];
+	}
+	else if (addr >= 0x8000 && addr <= 0x9FFF) {
+		// video ram
+		return vram[addr - 0x8000];
+	}
+	else if (addr >= 0xA000 && addr <= 0xBFFF) {
+		// external ram
+		return externalRam[addr - 0xA000];
+	}
+	else if (addr >= 0xC000 && addr <= 0xDFFF) {
+		// wram
+		return wram[addr - 0xC000];
+	}
+	else if (addr >= 0xE000 && addr <= 0xFDFF) {
+		// echo ram, prohibited
+		return 0x00;
+	}
+	else if (addr >= 0xFE00 && addr <= 0xFE9F) {
+		// oam ram
+		return oam[addr - 0xFE00];
+	}
+	else if (addr >= 0xFEA0 && addr <= 0xFEFF) {
+		// unusable
+		return 0x00;
+	}
+	else if (addr >= 0xFF00 && addr <= 0xFF7F) {
+		// io registers
+		return ioRegisters[addr - 0xFF00];
+	}
+	else if (addr >= 0xFF80 && addr <= 0xFFFE) {
+		// hram
+		return hram[addr - 0xFF80];
+	}
+	else if (addr == 0xFFFF) {
+		// ie register
+		return ieRegister[addr - 0xFFFF];
 	}
 
 	return 0x00;
+}
+
+void Bus::insertCartridge(const std::shared_ptr<Cartridge>& cartridge) {
+	this->cartridge = cartridge;
 }

--- a/src/Bus.cpp
+++ b/src/Bus.cpp
@@ -4,6 +4,9 @@ Bus::Bus() {
 	// Connect CPU to bus
 	cpu.connectBus(this);
 
+	// Connect PPU to bus
+	ppu.connectBus(this);
+
 	// Initialize data to 0
 	vram.fill(0x00);
 	externalRam.fill(0x00);
@@ -113,6 +116,5 @@ void Bus::clock() {
 	// Execute one CPU clock cycle
 	cpu.clock();
 
-	// Increment LY to simulate vblank
-	cpu.simLY();
+	ppu.clock();
 }

--- a/src/Bus.cpp
+++ b/src/Bus.cpp
@@ -15,6 +15,9 @@ Bus::Bus() {
 	ioRegisters.fill(0x00);
 	hram.fill(0x00);
 	ieRegister.fill(0x00);
+
+	// Set joypad register to high for now
+	ioRegisters[0x0000] = 0xFF;
 }
 
 Bus::~Bus() {
@@ -53,8 +56,13 @@ void Bus::write(uint16_t addr, uint8_t data) {
 		// io registers
 		
 		// Set joypad input to detect no button presses for now
-		if (addr == 0xFF00) {
+		/*if (addr == 0xFF00) {
 			data |= 0x0F;
+		}*/
+		
+		// Set joypad input to read only for now
+		if (addr == 0xFF00) {
+			return;
 		}
 
 		ioRegisters[addr - 0xFF00] = data;
@@ -88,7 +96,7 @@ uint8_t Bus::read(uint16_t addr) {
 	}
 	else if (addr >= 0xE000 && addr <= 0xFDFF) {
 		// echo ram, prohibited
-		return 0x00;
+		return 0xFF;
 	}
 	else if (addr >= 0xFE00 && addr <= 0xFE9F) {
 		// oam ram
@@ -96,7 +104,7 @@ uint8_t Bus::read(uint16_t addr) {
 	}
 	else if (addr >= 0xFEA0 && addr <= 0xFEFF) {
 		// unusable
-		return 0x00;
+		return 0xFF;
 	}
 	else if (addr >= 0xFF00 && addr <= 0xFF7F) {
 		// io registers
@@ -111,7 +119,7 @@ uint8_t Bus::read(uint16_t addr) {
 		return ieRegister[addr - 0xFFFF];
 	}
 
-	return 0x00;
+	return 0xFF;
 }
 
 void Bus::insertCartridge(const std::shared_ptr<Cartridge>& cartridge) {

--- a/src/Bus.cpp
+++ b/src/Bus.cpp
@@ -108,3 +108,11 @@ uint8_t Bus::read(uint16_t addr) {
 void Bus::insertCartridge(const std::shared_ptr<Cartridge>& cartridge) {
 	this->cart = cartridge;
 }
+
+void Bus::clock() {
+	// Execute one CPU clock cycle
+	cpu.clock();
+
+	// Increment LY to simulate vblank
+	cpu.simLY();
+}

--- a/src/Bus.cpp
+++ b/src/Bus.cpp
@@ -1,13 +1,17 @@
 #include "Bus.h"
 
 Bus::Bus() {
-	// Clear RAM
-	/*for (auto& i : ram) {
-		i = 0x00;
-	}*/
-
 	// Connect CPU to bus
 	cpu.connectBus(this);
+
+	// Initialize data to 0
+	vram.fill(0x00);
+	externalRam.fill(0x00);
+	wram.fill(0x00);
+	oam.fill(0x00);
+	ioRegisters.fill(0x00);
+	hram.fill(0x00);
+	ieRegister.fill(0x00);
 }
 
 Bus::~Bus() {
@@ -15,8 +19,8 @@ Bus::~Bus() {
 
 void Bus::write(uint16_t addr, uint8_t data) {
 	if (addr >= 0x0000 && addr <= 0x7FFF) {
-		// cartridge
-		rom[addr] = data;
+		// cartridge, invalid to write to
+		return;
 	}
 	else if (addr >= 0x8000 && addr <= 0x9FFF) {
 		// video ram
@@ -59,7 +63,7 @@ void Bus::write(uint16_t addr, uint8_t data) {
 uint8_t Bus::read(uint16_t addr) {
 	if (addr >= 0x0000 && addr <= 0x7FFF) {
 		// cartridge, fixed bank
-		return rom[addr];
+		return cart->read(addr);
 	}
 	else if (addr >= 0x8000 && addr <= 0x9FFF) {
 		// video ram
@@ -102,5 +106,5 @@ uint8_t Bus::read(uint16_t addr) {
 }
 
 void Bus::insertCartridge(const std::shared_ptr<Cartridge>& cartridge) {
-	this->cartridge = cartridge;
+	this->cart = cartridge;
 }

--- a/src/Bus.h
+++ b/src/Bus.h
@@ -17,11 +17,9 @@ public:
 	// Devices on bus
 	CPU cpu;
 	PPU ppu;
-	std::shared_ptr<Cartridge> cartridge;
+	std::shared_ptr<Cartridge> cart;
 
-	// Sections of memory
-	
-	std::array<uint8_t, 32 * 1024> rom;
+	// Sections of memory (excluding rom which is on cartridge)
 	std::array<uint8_t, 8 * 1024> vram;
 	std::array<uint8_t, 8 * 1024> externalRam;
 	std::array<uint8_t, 8 * 1024> wram;

--- a/src/Bus.h
+++ b/src/Bus.h
@@ -2,8 +2,11 @@
 
 #include <cstdint>
 #include <array>
+#include <memory>
 
 #include "CPU.h"
+#include "PPU.h"
+#include "Cartridge.h"
 
 class Bus {
 public:
@@ -12,15 +15,27 @@ public:
 
 public:
 	// Devices on bus
-	// CPU
 	CPU cpu;
+	PPU ppu;
+	std::shared_ptr<Cartridge> cartridge;
 
-	// Fake RAM for now, 64 KB addressable space so I'll use that for now
-	std::array<uint8_t, 64 * 1024> ram;
+	// Sections of memory
+	
+	std::array<uint8_t, 32 * 1024> rom;
+	std::array<uint8_t, 8 * 1024> vram;
+	std::array<uint8_t, 8 * 1024> externalRam;
+	std::array<uint8_t, 8 * 1024> wram;
+	std::array<uint8_t, 160> oam;
+	std::array<uint8_t, 128> ioRegisters;
+	std::array<uint8_t, 128> hram;
+	std::array<uint8_t, 1> ieRegister;
 
 public:
 	// Bus read and write
 	// Should be 16 bit addresses with 8 bit data, read one register at a time I think
 	void write(uint16_t addr, uint8_t data);
 	uint8_t read(uint16_t addr);
+
+	void insertCartridge(const std::shared_ptr<Cartridge>& cartridge);
+	void clock();
 };

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -1984,39 +1984,6 @@ uint8_t CPU::SWAP() {
 	return 0;
 }
 
-void CPU::simLY() {
-	// First check if screen is off and reset everything if so
-	if (!(bus->read(0xFF40) & 0x80)) {
-		// LCD off
-		bus->write(0xFF44, 0x00);
-		scanline_clock = 0;
-
-		return;
-	}
-	
-	bool inc = false;
-	
-	// Increment every 456 real clock cycles
-	scanline_clock++;
-	if (scanline_clock > 455) {
-		scanline_clock = 0;
-		
-		inc = true;
-	}
-
-	if (inc) {
-		uint8_t value = bus->read(0xFF44);
-
-		// reset after 154 cycles
-		value++;
-		if (value > 153) {
-			value = 0x00;
-		}
-
-		bus->write(0xFF44, value);
-	}
-}
-
 uint8_t CPU::interrupt_handler() {
 	// Early out if IME is off
 	if (IME == 0) {

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -348,6 +348,9 @@ uint8_t CPU::read(uint16_t addr) {
 }
 
 void CPU::clock() {
+	// Handle interrupts
+	interrupt_handler();
+
 	// If cycles remaining for an instruction is 0, read next byte
 	if (cycles == 0 && !halt_state) {
 		opcode = read(pc);
@@ -396,6 +399,11 @@ void CPU::clock() {
 	if (halt_state) {
 		cycles = halt_cycle();
 	}
+
+	// Execute timer function
+	// TODO: when should this be? I think it just needs to be "before" the interrupt handler
+	// so that it catches the overflow before the next instruction occurs.
+	timer();
 
 	global_cycles++;
 

--- a/src/CPU.h
+++ b/src/CPU.h
@@ -86,7 +86,6 @@ private:
 	bool halt_state = false;
 	bool initial_pending_interrupt = false;
 	
-	uint16_t scanline_clock = 0;
 	uint16_t divider_clock = 0;
 	uint16_t timer_clock = 0;
 	

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -1,9 +1,25 @@
+#include <fstream>
+
 #include "Cartridge.h"
 
-Cartridge::Cartridge(const std::string& fileName) {
 
+Cartridge::Cartridge(const std::string& fileName) {	
+	// Initialize with 0s
+	rom.fill(0x00);
+
+	// Load file into rom array
+	std::ifstream ifs;
+	ifs.open(fileName, std::ifstream::binary);
+	if (ifs.is_open()) {
+		ifs.read((char*)rom.data(), rom.size());
+		ifs.close();
+	}
 }
 
 Cartridge::~Cartridge() {
 
+}
+
+uint8_t Cartridge::read(uint16_t addr) {
+	return rom[addr];
 }

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -1,0 +1,9 @@
+#include "Cartridge.h"
+
+Cartridge::Cartridge(const std::string& fileName) {
+
+}
+
+Cartridge::~Cartridge() {
+
+}

--- a/src/Cartridge.h
+++ b/src/Cartridge.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <array>
 
 class Cartridge {
 public:
@@ -9,7 +9,9 @@ public:
 	~Cartridge();
 
 public:
-	void write(uint16_t addr, uint8_t data);
+	std::array<uint8_t, 32 * 1024> rom;
+
+public:
 	uint8_t read(uint16_t addr);
 };
 

--- a/src/Cartridge.h
+++ b/src/Cartridge.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class Cartridge {
+public:
+	Cartridge(const std::string& fileName);
+	~Cartridge();
+
+public:
+	void write(uint16_t addr, uint8_t data);
+	uint8_t read(uint16_t addr);
+};
+

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -1,0 +1,47 @@
+#include "PPU.h"
+
+PPU::PPU() {
+
+}
+
+PPU::~PPU() {
+
+}
+
+void PPU::write(uint16_t addr, uint8_t data) {
+
+}
+
+uint8_t PPU::read(uint16_t addr) {	
+	uint8_t data = 0x00;
+
+	// handle data in each of the 12 registers of the ppu
+	switch (addr) {
+	case 0xFF40:
+		break;
+	case 0xFF41:
+		break;
+	case 0xFF42:
+		break;
+	case 0xFF43:
+		break;
+	case 0xFF44:
+		break;
+	case 0xFF45:
+		break;
+	case 0xFF46:
+		break;
+	case 0xFF47:
+		break;
+	case 0xFF48:
+		break;
+	case 0xFF49:
+		break;
+	case 0xFF4A:
+		break;
+	case 0xFF4B:
+		break;
+	}
+
+	return data;
+}

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -5,12 +5,10 @@
 #include "PPU.h"
 
 PPU::PPU() {
-	// TODO: check most logical order for these
 	palette[0] = olc::Pixel(155, 188, 155);
 	palette[1] = olc::Pixel(139, 172, 139);
 	palette[2] = olc::Pixel(48, 98, 48);
 	palette[3] = olc::Pixel(15, 56, 15);
-	
 }
 
 PPU::~PPU() {
@@ -134,86 +132,6 @@ void PPU::updateLY() {
 }
 
 void PPU::updateTileData() {
-	// First check LCD mode
-	if (bus->read(0xFF40) & (1 << 4)) {
-		lcdc4 = true;
-	}
-	else {
-		lcdc4 = false;
-	}
-
-	// If lcdc4 = 1, block0 is 0-127 and block1 is 128-255
-	// If lcdc4 = 0, block2 is 0-127 and block1 is 128-255
-	uint16_t block0_start = 0x8000;
-	uint16_t block1_start = 0x8800;
-	uint16_t block2_start = 0x9000;
-
-	auto set_line = [&](olc::Sprite* block, uint8_t x, uint8_t y, uint8_t hi, uint8_t lo) {
-		// Get palette index from leftmost to rightmost pixel
-		block->SetPixel(x, y,		palette[((hi >> 6) & (1 << 1)) | ((lo >> 7) & 1)]);
-		block->SetPixel(x + 1, y,	palette[((hi >> 5) & (1 << 1)) | ((lo >> 6) & 1)]);
-		block->SetPixel(x + 2, y,	palette[((hi >> 4) & (1 << 1)) | ((lo >> 5) & 1)]);
-		block->SetPixel(x + 3, y,	palette[((hi >> 3) & (1 << 1)) | ((lo >> 4) & 1)]);
-
-		block->SetPixel(x + 4, y,	palette[((hi >> 2) & (1 << 1)) | ((lo >> 3) & 1)]);
-		block->SetPixel(x + 5, y,	palette[((hi >> 1) & (1 << 1)) | ((lo >> 2) & 1)]);
-		block->SetPixel(x + 6, y,	palette[((hi >> 0) & (1 << 1)) | ((lo >> 1) & 1)]);
-		block->SetPixel(x + 7, y,	palette[((hi << 1) & (1 << 1)) | ((lo >> 0) & 1)]);
-	};
-
-	uint8_t y_base = 0;
-	uint8_t y = y_base;
-	uint8_t x = 0;
-
-
-	for (int i = 0; i < 0x0800; i += 2) {
-		uint8_t lo0 = bus->read(block0_start + i);
-		uint8_t hi0 = bus->read(block0_start + i + 1);
-
-		uint8_t lo1 = bus->read(block1_start + i);
-		uint8_t hi1 = bus->read(block1_start + i + 1);
-
-		uint8_t lo2 = bus->read(block2_start + i);
-		uint8_t hi2 = bus->read(block2_start + i + 1);
-
-		// Set the line of pixels
-		//std::cout << "writing x, y: " << x * 8 << ", " << y + y_base << std::endl;
-		//std::cout << "block index: " << (block0_start + i) << std::endl;
-		set_line(block0, x * 8, y + y_base, hi0, lo0);
-		set_line(block1, x * 8, y + y_base, hi1, lo1);
-		set_line(block2, x * 8, y + y_base, hi2, lo1);
-
-		// TODO: refactor counting logic
-		
-		// Increment y after every line
-		y++;
-
-		// If y exceeds 8, the tile is done so increment x by 8 and set y to 0
-		if (y > 7) {
-			x++;
-			y = 0;
-		}
-
-		// If x exceeds 16, row of tiles is done so increment y_base and reset x to 0
-		if (x > 15) {
-			x = 0;
-			y_base += 8;
-		}
-	}
-
-}
-
-void PPU::updateTileDataTest() {
-	// First check LCD mode
-	if (bus->read(0xFF40) & (1 << 4)) {
-		lcdc4 = true;
-	}
-	else {
-		lcdc4 = false;
-	}
-
-	// If lcdc4 = 1, block0 is 0-127 and block1 is 128-255
-	// If lcdc4 = 0, block2 is 0-127 and block1 is 128-255
 	uint16_t block0_start = 0x8000;
 	uint16_t block1_start = 0x8800;
 	uint16_t block2_start = 0x9000;
@@ -250,7 +168,6 @@ void PPU::updateTileDataTest() {
 			set_line(block2, x * 8, j + y * 8, hi2, lo1);
 		}
 	}
-
 }
 
 void PPU::updateTileMap() {
@@ -297,7 +214,7 @@ void PPU::updateTileMap() {
 		uint8_t index = bus->read(bg_start + i);
 		uint16_t start = (index > 127) ? second_half_start : first_half_start;
 		
-		// TODO: cleanup logic
+		// TODO: clean up logic
 		// Read each pair of bytes and set each of the 8 lines of pixels
 		for (int j = 0; j < 8; j++) {
 			uint8_t lo = bus->read(start + (index % 128) * 16 + j * 2);

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -1,7 +1,13 @@
+#include "Bus.h"
+
 #include "PPU.h"
 
 PPU::PPU() {
-
+	// TODO: check most logical order for these
+	palette_screen[0] = olc::Pixel(15, 56, 15);
+	palette_screen[1] = olc::Pixel(48, 98, 48);
+	palette_screen[2] = olc::Pixel(139, 172, 139);
+	palette_screen[3] = olc::Pixel(155, 188, 155);
 }
 
 PPU::~PPU() {
@@ -9,7 +15,7 @@ PPU::~PPU() {
 }
 
 void PPU::write(uint16_t addr, uint8_t data) {
-
+	delete sprite_screen;
 }
 
 uint8_t PPU::read(uint16_t addr) {	
@@ -44,4 +50,60 @@ uint8_t PPU::read(uint16_t addr) {
 	}
 
 	return data;
+}
+
+olc::Sprite* PPU::getScreen() {
+	return sprite_screen;
+}
+
+void PPU::clock() {
+	int random_colour = rand() % 4;
+	sprite_screen->SetPixel(cycle - 1, scanline, palette_screen[random_colour]);
+	//sprite_screen->SetPixel(cycle - 1, scanline, palette_screen[(rand() % 4)]);
+
+	// Update LY
+	updateLY();
+
+}
+
+void PPU::updateLY() {
+	// TODO: does it make sense for the PPU to read random areas of memory other than vram and oam?
+	// First check if screen is off and reset everything if so
+	if (!(bus->read(0xFF40) & 0x80)) {
+		// LCD off
+		bus->write(0xFF44, 0x00);
+		cycle = 0;
+
+		return;
+	}
+
+	bool inc = false;
+	
+	// Reset to false every frame
+	frame_complete = false;
+
+	// Increment every 456 real clock cycles
+	cycle++;
+	if (cycle > 455) {
+		cycle = 0;
+
+		inc = true;
+	}
+
+	if (inc) {
+		scanline = bus->read(0xFF44);
+
+		// reset after 154 cycles
+		scanline++;
+		if (scanline > 153) {
+			scanline = 0x00;
+			frame_complete = true;
+		}
+
+		bus->write(0xFF44, scanline);
+	}
+}
+
+bool PPU::frameComplete() {
+	return frame_complete;
 }

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -116,8 +116,14 @@ void PPU::updateLY() {
 	if (inc) {
 		scanline = bus->read(0xFF44);
 
-		// reset after 154 cycles
+		// Reset after 154 cycles
 		scanline++;
+		
+		// Set VBLANK interrupt flag when LY is 144
+		if (scanline == 144) {
+			bus->write(0xFF0F, (1 << 0));
+		}
+
 		if (scanline > 153) {
 			scanline = 0x00;
 			frame_complete = true;
@@ -300,5 +306,12 @@ void PPU::updateTileMap() {
 			set_line(bg_map, x * 8, j + y * 8, hi, lo);
 		}
 	}
+}
 
+uint8_t PPU::getSCY() {
+	return bus->read(0xFF42);
+}
+
+uint8_t PPU::getSCX() {
+	return bus->read(0xFF43);
 }

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -6,10 +6,11 @@
 
 PPU::PPU() {
 	// TODO: check most logical order for these
-	palette[0] = olc::Pixel(15, 56, 15);
-	palette[1] = olc::Pixel(48, 98, 48);
-	palette[2] = olc::Pixel(139, 172, 139);
-	palette[3] = olc::Pixel(155, 188, 155);
+	palette[0] = olc::Pixel(155, 188, 155);
+	palette[1] = olc::Pixel(139, 172, 139);
+	palette[2] = olc::Pixel(48, 98, 48);
+	palette[3] = olc::Pixel(15, 56, 15);
+	
 }
 
 PPU::~PPU() {
@@ -73,6 +74,15 @@ olc::Sprite* PPU::getTileData(int block_num) {
 	}
 }
 
+olc::Sprite* PPU::getTileMap(int map_num) {
+	if (map_num == 0) {
+		return bg_map;
+	}
+	else {
+		return win_map;
+	}
+}
+
 void PPU::clock() {
 	int random_colour = rand() % 4;
 	sprite_screen->SetPixel(cycle - 1, scanline, palette[random_colour]);
@@ -94,9 +104,6 @@ void PPU::updateLY() {
 	}
 
 	bool inc = false;
-	
-	// Reset to false every frame
-	frame_complete = false;
 
 	// Increment every 456 real clock cycles
 	cycle++;
@@ -120,14 +127,13 @@ void PPU::updateLY() {
 	}
 }
 
-bool PPU::frameComplete() {
-	return frame_complete;
-}
-
 void PPU::updateTileData() {
 	// First check LCD mode
 	if (bus->read(0xFF40) & (1 << 4)) {
 		lcdc4 = true;
+	}
+	else {
+		lcdc4 = false;
 	}
 
 	// If lcdc4 = 1, block0 is 0-127 and block1 is 128-255
@@ -166,6 +172,7 @@ void PPU::updateTileData() {
 
 		// Set the line of pixels
 		//std::cout << "writing x, y: " << x * 8 << ", " << y + y_base << std::endl;
+		//std::cout << "block index: " << (block0_start + i) << std::endl;
 		set_line(block0, x * 8, y + y_base, hi0, lo0);
 		set_line(block1, x * 8, y + y_base, hi1, lo1);
 		set_line(block2, x * 8, y + y_base, hi2, lo1);
@@ -185,6 +192,112 @@ void PPU::updateTileData() {
 		if (x > 15) {
 			x = 0;
 			y_base += 8;
+		}
+	}
+
+}
+
+void PPU::updateTileDataTest() {
+	// First check LCD mode
+	if (bus->read(0xFF40) & (1 << 4)) {
+		lcdc4 = true;
+	}
+	else {
+		lcdc4 = false;
+	}
+
+	// If lcdc4 = 1, block0 is 0-127 and block1 is 128-255
+	// If lcdc4 = 0, block2 is 0-127 and block1 is 128-255
+	uint16_t block0_start = 0x8000;
+	uint16_t block1_start = 0x8800;
+	uint16_t block2_start = 0x9000;
+
+	auto set_line = [&](olc::Sprite* block, uint8_t x, uint8_t y, uint8_t hi, uint8_t lo) {
+		// Get palette index from leftmost to rightmost pixel
+		block->SetPixel(x, y, palette[((hi >> 6) & (1 << 1)) | ((lo >> 7) & 1)]);
+		block->SetPixel(x + 1, y, palette[((hi >> 5) & (1 << 1)) | ((lo >> 6) & 1)]);
+		block->SetPixel(x + 2, y, palette[((hi >> 4) & (1 << 1)) | ((lo >> 5) & 1)]);
+		block->SetPixel(x + 3, y, palette[((hi >> 3) & (1 << 1)) | ((lo >> 4) & 1)]);
+
+		block->SetPixel(x + 4, y, palette[((hi >> 2) & (1 << 1)) | ((lo >> 3) & 1)]);
+		block->SetPixel(x + 5, y, palette[((hi >> 1) & (1 << 1)) | ((lo >> 2) & 1)]);
+		block->SetPixel(x + 6, y, palette[((hi >> 0) & (1 << 1)) | ((lo >> 1) & 1)]);
+		block->SetPixel(x + 7, y, palette[((hi << 1) & (1 << 1)) | ((lo >> 0) & 1)]);
+	};
+
+	for (int i = 0; i < 0x0100; i++) {
+		uint8_t x = i % 16;
+		uint8_t y = i / 16;
+
+		for (int j = 0; j < 8; j++) {
+			uint8_t lo0 = bus->read(block0_start + i * 16 + j * 2);
+			uint8_t hi0 = bus->read(block0_start + i * 16 + j * 2 + 1);
+
+			uint8_t lo1 = bus->read(block1_start + i * 16 + j * 2);
+			uint8_t hi1 = bus->read(block1_start + i * 16 + j * 2 + 1);
+
+			uint8_t lo2 = bus->read(block2_start + i * 16 + j * 2);
+			uint8_t hi2 = bus->read(block2_start + i * 16 + j * 2 + 1);
+
+			set_line(block0, x * 8, j + y * 8, hi0, lo0);
+			set_line(block1, x * 8, j + y * 8, hi1, lo1);
+			set_line(block2, x * 8, j + y * 8, hi2, lo1);
+		}
+	}
+
+}
+
+void PPU::updateTileMap() {
+	// Check LCD control
+	lcdc4 = bus->read(0xFF40) & (1 << 4);
+	lcdc6 = bus->read(0xFF40) & (1 << 6);
+	lcdc3 = bus->read(0xFF40) & (1 << 3);
+	lcdc5 = bus->read(0xFF40) & (1 << 5);
+	lcdc7 = bus->read(0xFF40) & (1 << 7);
+
+	// Early out if LCD is off
+	if (!lcdc7) {
+		return;
+	}
+
+	// If lcdc4 = 1, 0-127 starts at 0x8000 and 128-255 starts at 0x8800
+	// If lcdc4 = 0, 0-127 starts at 0x9000 and 128-255 starts at 0x8800
+	uint16_t first_half_start = lcdc4 ? 0x8000 : 0x9000;
+	uint16_t second_half_start = 0x8800;
+
+	// If lcdc3 = 1, bg map starts at 0x9C00, otherwise 0x9800
+	uint16_t bg_start = lcdc3 ? 0x9C00 : 0x9800;
+
+	// If lcdc6 = 1, win map starts at 0x9C00, otherwise 0x9800
+	uint16_t win_start = lcdc6 ? 0x9C00 : 0x9800;
+	
+	auto set_line = [&](olc::Sprite* map, uint8_t x, uint8_t y, uint8_t hi, uint8_t lo) {
+		// Get palette index from leftmost to rightmost pixel
+		map->SetPixel(x, y,		palette[((hi >> 6) & (1 << 1)) | ((lo >> 7) & 1)]);
+		map->SetPixel(x + 1, y, palette[((hi >> 5) & (1 << 1)) | ((lo >> 6) & 1)]);
+		map->SetPixel(x + 2, y, palette[((hi >> 4) & (1 << 1)) | ((lo >> 5) & 1)]);
+		map->SetPixel(x + 3, y, palette[((hi >> 3) & (1 << 1)) | ((lo >> 4) & 1)]);
+
+		map->SetPixel(x + 4, y, palette[((hi >> 2) & (1 << 1)) | ((lo >> 3) & 1)]);
+		map->SetPixel(x + 5, y, palette[((hi >> 1) & (1 << 1)) | ((lo >> 2) & 1)]);
+		map->SetPixel(x + 6, y, palette[((hi >> 0) & (1 << 1)) | ((lo >> 1) & 1)]);
+		map->SetPixel(x + 7, y, palette[((hi << 1) & (1 << 1)) | ((lo >> 0) & 1)]);
+	};
+
+	for (int i = 0; i < 0x0400; i++) {
+		uint8_t x = i % 32;
+		uint8_t y = i / 32;
+
+		uint8_t index = bus->read(bg_start + i);
+		uint16_t start = (index > 127) ? second_half_start : first_half_start;
+		
+		// TODO: cleanup logic
+		// Read each pair of bytes and set each of the 8 lines of pixels
+		for (int j = 0; j < 8; j++) {
+			uint8_t lo = bus->read(start + (index % 128) * 16 + j * 2);
+			uint8_t hi = bus->read(start + (index % 128) * 16 + j * 2 + 1);
+
+			set_line(bg_map, x * 8, j + y * 8, hi, lo);
 		}
 	}
 

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -2,15 +2,39 @@
 
 #include <cstdint>
 
+#include "olcPixelGameEngine.h"
+
+#include "Cartridge.h"
+
+class Bus;
+
 class PPU {
 public:
 	PPU();
 	~PPU();
 
 public:
+	// Link CPU to bus
+	void connectBus(Bus* n) { bus = n; };
 	void write(uint16_t addr, uint8_t data);
 	uint8_t read(uint16_t addr);
 
+	olc::Sprite* getScreen();
+
 	void clock();
+	void updateLY();
+
+	bool frameComplete();
+
+private:
+	Bus* bus = nullptr;
+	olc::Pixel palette_screen[4];
+	olc::Sprite* sprite_screen = new olc::Sprite(160, 144);
+	//olc::Sprite spriteScreen(160, 144);
+
+	uint16_t cycle = 0;
+	uint8_t scanline = 0;
+
+	bool frame_complete = false;
 };
 

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -30,6 +30,9 @@ public:
 	void updateTileDataTest();
 	void updateTileMap();
 
+	uint8_t getSCY();
+	uint8_t getSCX();
+
 	bool frame_complete = false;
 
 private:

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -20,21 +20,29 @@ public:
 	uint8_t read(uint16_t addr);
 
 	olc::Sprite* getScreen();
+	olc::Sprite* getTileData(int block_num);
 
 	void clock();
 	void updateLY();
+
+	void updateTileData();
 
 	bool frameComplete();
 
 private:
 	Bus* bus = nullptr;
-	olc::Pixel palette_screen[4];
+	olc::Pixel palette[4];
 	olc::Sprite* sprite_screen = new olc::Sprite(160, 144);
-	//olc::Sprite spriteScreen(160, 144);
+	
+	olc::Sprite* block0 = new olc::Sprite(128, 64);
+	olc::Sprite* block1 = new olc::Sprite(128, 64);
+	olc::Sprite* block2 = new olc::Sprite(128, 64);
 
 	uint16_t cycle = 0;
 	uint8_t scanline = 0;
 
 	bool frame_complete = false;
+
+	bool lcdc4 = false;
 };
 

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -27,7 +27,6 @@ public:
 	void updateLY();
 
 	void updateTileData();
-	void updateTileDataTest();
 	void updateTileMap();
 
 	uint8_t getSCY();

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -21,13 +21,16 @@ public:
 
 	olc::Sprite* getScreen();
 	olc::Sprite* getTileData(int block_num);
+	olc::Sprite* getTileMap(int map_num);
 
 	void clock();
 	void updateLY();
 
 	void updateTileData();
+	void updateTileDataTest();
+	void updateTileMap();
 
-	bool frameComplete();
+	bool frame_complete = false;
 
 private:
 	Bus* bus = nullptr;
@@ -38,11 +41,19 @@ private:
 	olc::Sprite* block1 = new olc::Sprite(128, 64);
 	olc::Sprite* block2 = new olc::Sprite(128, 64);
 
+	olc::Sprite* bg_map = new olc::Sprite(256, 256);
+	olc::Sprite* win_map = new olc::Sprite(256, 256);
+
 	uint16_t cycle = 0;
 	uint8_t scanline = 0;
 
-	bool frame_complete = false;
-
 	bool lcdc4 = false;
+	
+	bool lcdc6 = false;
+	bool lcdc3 = false;
+
+	bool lcdc5 = false;
+
+	bool lcdc7 = false;
 };
 

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+class PPU {
+public:
+	PPU();
+	~PPU();
+
+public:
+	void write(uint16_t addr, uint8_t data);
+	uint8_t read(uint16_t addr);
+
+	void clock();
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,21 +170,27 @@ public:
 	bool OnUserUpdate(float fElapsedTime) {
 		Clear(olc::DARK_BLUE);
 
-		if (GetKey(olc::Key::SPACE).bPressed) {
+		/*if (GetKey(olc::Key::SPACE).bPressed) {
 			dmg.tick();
-		}
+		}*/
+
+		do {
+			dmg.tick();
+		} while (!dmg.bus.ppu.frameComplete());
 
 		// TODO: what exactly should I draw?
-		DrawRam(2, 2, 0x0000, 16, 16);
-		DrawRam(2, 182, 0xFF00, 16, 16);
-		DrawCPU(448, 2);
+		//DrawRam(2, 2, 0x0000, 16, 16);
+		//DrawRam(2, 182, 0xFF00, 16, 16);
+		//DrawCPU(448, 2);
+
+		DrawSprite(0, 0, dmg.bus.ppu.getScreen(), 2);
 
 		return true;
 	}
 };
 
 int main() {
-	bool graphics = false;
+	bool graphics = true;
 	
 	if (graphics) {
 		Demo demo;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ public:
 
 	bool init() {
 		// Passing 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, instr_timing
-		size_t test_num = 1;
+		size_t test_num = 2;
 		
 		// Load boot rom
 		unsigned char memory[0x10000];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,13 +48,13 @@
 class DMG {
 public:
 	Bus bus;
+	std::shared_ptr<Cartridge> cart;
 
 	bool init() {
 		// Passing 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, instr_timing
 		size_t test_num = 2;
 		
-		// Load boot rom
-		unsigned char memory[0x10000];
+		// Get rom name
 		std::string test_roms[] = {
 			"cpu_instrs.gb",
 			"01-special.gb",
@@ -70,22 +70,13 @@ public:
 			"11-op a,(hl).gb",
 			"instr_timing.gb"
 		};
-		std::string rom = "test-roms/" + test_roms[test_num];
-		FILE* file = fopen(rom.c_str(), "rb");
-		int pos = 0;
-		while (fread(&memory[pos], 1, 1, file)) {
-			pos++;
-		}
-		fclose(file);
+		std::string romName = "test-roms/" + test_roms[test_num];
 
-		// Copy bootrom into memory
-		pos = 0;
-		for (auto m : memory) {
-			bus.write(pos, m);
-			pos++;
-		}
+		// Create cartridge
+		cart = std::make_shared<Cartridge>(romName);
+		bus.insertCartridge(cart);
 
-		std::cout << "Beginning execution of " << rom << std::endl;
+		std::cout << "Beginning execution of " << romName << std::endl;
 
 		bus.cpu.print_toggle = false;
 		bus.cpu.log_toggle = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,7 +186,9 @@ public:
 			residual_time += (1.0f / 60.0f) - fElapsedTime;
 			do {
 				dmg.tick();
-			} while (!dmg.bus.ppu.frameComplete());
+			} while (!dmg.bus.ppu.frame_complete);
+			
+			dmg.bus.ppu.frame_complete = false;
 		}
 
 
@@ -196,13 +198,20 @@ public:
 		//DrawCPU(448, 2);
 
 		// Update TileData for testing once per frame
-		dmg.bus.ppu.updateTileData();
+		dmg.bus.ppu.updateTileDataTest();
+		dmg.bus.ppu.updateTileMap();
 
-		DrawSprite(320, 288 - 192, dmg.bus.ppu.getTileData(0), 1);
+		/*DrawSprite(320, 288 - 192, dmg.bus.ppu.getTileData(0), 1);
 		DrawSprite(320, 288 - 128, dmg.bus.ppu.getTileData(1), 1);
 		DrawSprite(320, 288 - 64, dmg.bus.ppu.getTileData(2), 1);
 
-		DrawSprite(0, 0, dmg.bus.ppu.getScreen(), 2);
+		DrawSprite(0, 0, dmg.bus.ppu.getScreen(), 2);*/
+
+		DrawSprite(256, 256 - 192, dmg.bus.ppu.getTileData(0), 1);
+		DrawSprite(256, 256 - 128, dmg.bus.ppu.getTileData(1), 1);
+		DrawSprite(256, 256 - 64, dmg.bus.ppu.getTileData(2), 1);
+		
+		DrawSprite(0, 0, dmg.bus.ppu.getTileMap(0), 1);
 
 		return true;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,7 @@ public:
 		};
 		std::string romName = "test-roms/" + test_roms[test_num];
 
-		//romName = "roms/tetris.gb";
+		romName = "roms/tetris.gb";
 
 		// Create cartridge
 		cart = std::make_shared<Cartridge>(romName);
@@ -207,11 +207,17 @@ public:
 
 		DrawSprite(0, 0, dmg.bus.ppu.getScreen(), 2);*/
 
-		DrawSprite(256, 256 - 192, dmg.bus.ppu.getTileData(0), 1);
-		DrawSprite(256, 256 - 128, dmg.bus.ppu.getTileData(1), 1);
-		DrawSprite(256, 256 - 64, dmg.bus.ppu.getTileData(2), 1);
+		int x = 160;
+		int y = 144;
+		int scale = 2;
+
+		DrawSprite(x * scale, y * scale - 192, dmg.bus.ppu.getTileData(0), 1);
+		DrawSprite(x * scale, y * scale - 128, dmg.bus.ppu.getTileData(1), 1);
+		DrawSprite(x * scale, y * scale - 64, dmg.bus.ppu.getTileData(2), 1);
 		
-		DrawSprite(0, 0, dmg.bus.ppu.getTileMap(0), 1);
+		//DrawSprite(0, 0, dmg.bus.ppu.getTileMap(0), 1);
+		// TODO: figure out a better scroll method
+		DrawPartialSprite(0, 0, dmg.bus.ppu.getTileMap(0), dmg.bus.ppu.getSCX(), dmg.bus.ppu.getSCY(), x, y, scale);
 
 		return true;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,18 +101,7 @@ public:
 
 	bool tick() {
 		do {
-			// Handle interrupts
-			bus.cpu.interrupt_handler();
-			
-			// Execute one clock cycle
-			bus.cpu.clock();
-			
-			// Increment LY to simulate vblank
-			bus.cpu.simLY();
-
-			// Execute timer function
-			bus.cpu.timer();
-
+			bus.clock();
 		} while (!bus.cpu.complete());
 
 		return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,10 +174,6 @@ public:
 	bool OnUserUpdate(float fElapsedTime) {
 		Clear(olc::DARK_BLUE);
 
-		/*if (GetKey(olc::Key::SPACE).bPressed) {
-			dmg.tick();
-		}*/
-
 		// Implement timer
 		if (residual_time > 0.0f) {
 			residual_time -= fElapsedTime;
@@ -191,21 +187,9 @@ public:
 			dmg.bus.ppu.frame_complete = false;
 		}
 
-
-		// TODO: what exactly should I draw?
-		//DrawRam(2, 2, 0x0000, 16, 16);
-		//DrawRam(2, 182, 0xFF00, 16, 16);
-		//DrawCPU(448, 2);
-
 		// Update TileData for testing once per frame
-		dmg.bus.ppu.updateTileDataTest();
+		dmg.bus.ppu.updateTileData();
 		dmg.bus.ppu.updateTileMap();
-
-		/*DrawSprite(320, 288 - 192, dmg.bus.ppu.getTileData(0), 1);
-		DrawSprite(320, 288 - 128, dmg.bus.ppu.getTileData(1), 1);
-		DrawSprite(320, 288 - 64, dmg.bus.ppu.getTileData(2), 1);
-
-		DrawSprite(0, 0, dmg.bus.ppu.getScreen(), 2);*/
 
 		int x = 160;
 		int y = 144;
@@ -215,7 +199,6 @@ public:
 		DrawSprite(x * scale, y * scale - 128, dmg.bus.ppu.getTileData(1), 1);
 		DrawSprite(x * scale, y * scale - 64, dmg.bus.ppu.getTileData(2), 1);
 		
-		//DrawSprite(0, 0, dmg.bus.ppu.getTileMap(0), 1);
 		// TODO: figure out a better scroll method
 		DrawPartialSprite(0, 0, dmg.bus.ppu.getTileMap(0), dmg.bus.ppu.getSCX(), dmg.bus.ppu.getSCY(), x, y, scale);
 


### PR DESCRIPTION
With this update I'm able to boot into Tetris. This PR splits the bus read and writes into the various devices connected to it. Most still need to be updated, and there may be a better way to organize things in the future.

This PR includes a start to the PPU as well, with functions to display the background tile map and tile data in the vram. I added the scroll registers as a crop to the sprite to simulate the correct scroll. I think I'm going to implement a frame buffer when I switch to SDL, so I'll likely have to rework much of the current PPU implementation.