### PR TITLE
Implement joypad input

### DIFF
--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -35,11 +35,9 @@ void MMU::write(uint16_t addr, uint8_t data) {
 			// TODO: Double check that this is the correct behaviour.
 			selectedButtons = &buttonsOff;
 		}
-		return;
 	}
 	else {
 		memory[addr] = data;
-		return;
 	}
 }
 
@@ -59,7 +57,7 @@ uint8_t MMU::read(uint16_t addr) {
 			return 0xFF;
 		}
 		else if (addr == 0xFF00) {
-			// Return the int that selected_buttons currently points to based on previous write
+			// Return the int that selectedButtons currently points to based on the previous write
 			return *selectedButtons;
 		}
 		else {
@@ -89,7 +87,7 @@ void MMU::writeDirectionButton(uint8_t pos, uint8_t value) {
 }
 
 void MMU::writeButton(uint8_t* buttons, uint8_t pos, uint8_t value) {
-	// Create mask for pos, then or with value
+	// Create mask for the bit at pos, then or with the value at pos
 	*buttons &= ~(1 << pos);
 	*buttons |= (value << pos);
 }

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -23,11 +23,23 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		return;
 	}
 	else if (addr == 0xFF00) {
-		// Set joypad input to read only for now
+		// Change which set of buttons is selected to be read from
+		if (~data & (1 << 5)) {
+			selectedButtons = &actionButtons;
+		}
+		else if (~data & (1 << 4)) {
+			selectedButtons = &directionButtons;
+		}
+		else {
+			// Set selected buttons to off, always 0xFF
+			// TODO: Double check that this is the correct behaviour.
+			selectedButtons = &buttonsOff;
+		}
 		return;
 	}
 	else {
 		memory[addr] = data;
+		return;
 	}
 }
 
@@ -46,6 +58,10 @@ uint8_t MMU::read(uint16_t addr) {
 			// unusable
 			return 0xFF;
 		}
+		else if (addr == 0xFF00) {
+			// Return the int that selected_buttons currently points to based on previous write
+			return *selectedButtons;
+		}
 		else {
 			return memory[addr];
 		}
@@ -62,4 +78,18 @@ uint8_t MMU::directRead(uint16_t addr) {
 
 void MMU::insertCartridge(const std::shared_ptr<Cartridge>& cartridge) {
 	this->cart = cartridge;
+}
+
+void MMU::writeActionButton(uint8_t pos, uint8_t value) {
+	writeButton(&actionButtons, pos, value);
+}
+
+void MMU::writeDirectionButton(uint8_t pos, uint8_t value) {
+	writeButton(&directionButtons, pos, value);
+}
+
+void MMU::writeButton(uint8_t* buttons, uint8_t pos, uint8_t value) {
+	// Create mask for pos, then or with value
+	*buttons &= ~(1 << pos);
+	*buttons |= (value << pos);
 }

--- a/src/MMU.h
+++ b/src/MMU.h
@@ -36,5 +36,5 @@ private:
 	uint8_t actionButtons = 0xFF;
 	uint8_t directionButtons = 0xFF;
 	uint8_t buttonsOff = 0xFF;
-	uint8_t* selectedButtons = &actionButtons;
+	uint8_t* selectedButtons = &buttonsOff;
 };

--- a/src/MMU.h
+++ b/src/MMU.h
@@ -26,4 +26,15 @@ public:
 	uint8_t directRead(uint16_t addr);
 
 	void insertCartridge(const std::shared_ptr<Cartridge>& cartridge);
+
+	// Set the values of the input
+	void writeActionButton(uint8_t pos, uint8_t value);
+	void writeDirectionButton(uint8_t pos, uint8_t value);
+	void writeButton(uint8_t* buttons, uint8_t pos, uint8_t value);
+
+private:
+	uint8_t actionButtons = 0xFF;
+	uint8_t directionButtons = 0xFF;
+	uint8_t buttonsOff = 0xFF;
+	uint8_t* selectedButtons = &actionButtons;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,32 +70,17 @@ public:
 				}
 			}
 
-			// Continuous inputs
-			if (keyboardState[SDL_SCANCODE_UP]) {
-				std::cout << "up" << std::endl;
-			}
-			if (keyboardState[SDL_SCANCODE_DOWN]) {
-				std::cout << "down" << std::endl;
-			}
-			if (keyboardState[SDL_SCANCODE_LEFT]) {
-				std::cout << "left" << std::endl;
-			}
-			if (keyboardState[SDL_SCANCODE_RIGHT]) {
-				std::cout << "right" << std::endl;
-			}
-			if (keyboardState[SDL_SCANCODE_Z]) {
-				std::cout << "A" << std::endl;
-			}
-			if (keyboardState[SDL_SCANCODE_X]) {
-				std::cout << "B" << std::endl;
-			}
-			if (keyboardState[SDL_SCANCODE_A]) {
-				std::cout << "start" << std::endl;
-			}
-			if (keyboardState[SDL_SCANCODE_S]) {
-				std::cout << "select" << std::endl;
-			}
+			// TODO: Is this way of handling input overengineered?
+			// 0 is pressed, 1 is unpressed
+			dmg.mmu.writeDirectionButton(0, keyboardState[SDL_SCANCODE_RIGHT]	? 0 : 1);
+			dmg.mmu.writeDirectionButton(1, keyboardState[SDL_SCANCODE_LEFT]	? 0 : 1);
+			dmg.mmu.writeDirectionButton(2, keyboardState[SDL_SCANCODE_UP]		? 0 : 1);
+			dmg.mmu.writeDirectionButton(3, keyboardState[SDL_SCANCODE_DOWN]	? 0 : 1);
 
+			dmg.mmu.writeActionButton(0, keyboardState[SDL_SCANCODE_Z] ? 0 : 1);	// A
+			dmg.mmu.writeActionButton(1, keyboardState[SDL_SCANCODE_X] ? 0 : 1);	// B
+			dmg.mmu.writeActionButton(2, keyboardState[SDL_SCANCODE_S] ? 0 : 1);	// Select
+			dmg.mmu.writeActionButton(3, keyboardState[SDL_SCANCODE_A] ? 0 : 1);	// Start
 
 			// Keep track of performance for fps display
 			uint64_t start = SDL_GetPerformanceCounter();
@@ -110,7 +95,7 @@ public:
 			uint64_t end = SDL_GetPerformanceCounter();
 			float elapsed = (end - start) / (float)SDL_GetPerformanceFrequency();
 			std::string fps = std::to_string((int)(1.0f / elapsed));
-			std::cout << fps << "\r" << std::flush;
+			//std::cout << fps << "\r" << std::flush;
 			//std::cout << dmg.mmu.cpu.global_cycles << "\r" << std::flush;
 		}
 		return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,36 +59,41 @@ public:
 
 	int execute() {
 		SDL_Event e;
+		const uint8_t* keyboardState = SDL_GetKeyboardState(NULL);
 		
 		bool quit = false;
-		while (!quit) {			
+		while (!quit) {
+			// Individual inputs
 			while (SDL_PollEvent(&e) != 0) {
 				if (e.type == SDL_QUIT) {
 					quit = true;
 				}
-				// TODO: Use this as an example for actual input.
-				/*else if (e.type == SDL_KEYDOWN) {
-					switch (e.key.keysym.sym) {
-					case SDLK_UP:
-						//SDL_FillRect(screenSurface, NULL, SDL_MapRGB(screenSurface->format, 0xFF, 0xFF, 0x00));
-						break;
-					
-					case SDLK_DOWN:
-						//SDL_FillRect(screenSurface, NULL, SDL_MapRGB(screenSurface->format, 0xFF, 0x00, 0x00));
-						break;
+			}
 
-					case SDLK_LEFT:
-						//SDL_FillRect(screenSurface, NULL, SDL_MapRGB(screenSurface->format, 0x00, 0xFF, 0x00));
-						break;
-
-					case SDLK_RIGHT:
-						//SDL_FillRect(screenSurface, NULL, SDL_MapRGB(screenSurface->format, 0x00, 0x00, 0xFF));
-						break;
-
-					default:
-						//SDL_FillRect(screenSurface, NULL, SDL_MapRGB(screenSurface->format, 0xFF, 0xFF, 0xFF));
-					}
-				}*/
+			// Continuous inputs
+			if (keyboardState[SDL_SCANCODE_UP]) {
+				std::cout << "up" << std::endl;
+			}
+			if (keyboardState[SDL_SCANCODE_DOWN]) {
+				std::cout << "down" << std::endl;
+			}
+			if (keyboardState[SDL_SCANCODE_LEFT]) {
+				std::cout << "left" << std::endl;
+			}
+			if (keyboardState[SDL_SCANCODE_RIGHT]) {
+				std::cout << "right" << std::endl;
+			}
+			if (keyboardState[SDL_SCANCODE_Z]) {
+				std::cout << "A" << std::endl;
+			}
+			if (keyboardState[SDL_SCANCODE_X]) {
+				std::cout << "B" << std::endl;
+			}
+			if (keyboardState[SDL_SCANCODE_A]) {
+				std::cout << "start" << std::endl;
+			}
+			if (keyboardState[SDL_SCANCODE_S]) {
+				std::cout << "select" << std::endl;
 			}
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,15 +72,15 @@ public:
 
 			// TODO: Is this way of handling input overengineered?
 			// 0 is pressed, 1 is unpressed
-			dmg.mmu.writeDirectionButton(0, keyboardState[SDL_SCANCODE_RIGHT]	? 0 : 1);
-			dmg.mmu.writeDirectionButton(1, keyboardState[SDL_SCANCODE_LEFT]	? 0 : 1);
-			dmg.mmu.writeDirectionButton(2, keyboardState[SDL_SCANCODE_UP]		? 0 : 1);
-			dmg.mmu.writeDirectionButton(3, keyboardState[SDL_SCANCODE_DOWN]	? 0 : 1);
+			dmg.mmu.writeDirectionButton(0, !keyboardState[SDL_SCANCODE_RIGHT]);
+			dmg.mmu.writeDirectionButton(1, !keyboardState[SDL_SCANCODE_LEFT]);
+			dmg.mmu.writeDirectionButton(2, !keyboardState[SDL_SCANCODE_UP]);
+			dmg.mmu.writeDirectionButton(3, !keyboardState[SDL_SCANCODE_DOWN]);
 
-			dmg.mmu.writeActionButton(0, keyboardState[SDL_SCANCODE_Z] ? 0 : 1);	// A
-			dmg.mmu.writeActionButton(1, keyboardState[SDL_SCANCODE_X] ? 0 : 1);	// B
-			dmg.mmu.writeActionButton(2, keyboardState[SDL_SCANCODE_S] ? 0 : 1);	// Select
-			dmg.mmu.writeActionButton(3, keyboardState[SDL_SCANCODE_A] ? 0 : 1);	// Start
+			dmg.mmu.writeActionButton(0, !keyboardState[SDL_SCANCODE_Z]);		// A
+			dmg.mmu.writeActionButton(1, !keyboardState[SDL_SCANCODE_X]);		// B
+			dmg.mmu.writeActionButton(2, !keyboardState[SDL_SCANCODE_S]);		// Select
+			dmg.mmu.writeActionButton(3, !keyboardState[SDL_SCANCODE_A]);		// Start
 
 			// Keep track of performance for fps display
 			uint64_t start = SDL_GetPerformanceCounter();
@@ -95,8 +95,7 @@ public:
 			uint64_t end = SDL_GetPerformanceCounter();
 			float elapsed = (end - start) / (float)SDL_GetPerformanceFrequency();
 			std::string fps = std::to_string((int)(1.0f / elapsed));
-			//std::cout << fps << "\r" << std::flush;
-			//std::cout << dmg.mmu.cpu.global_cycles << "\r" << std::flush;
+			std::cout << fps << "\r" << std::flush;
 		}
 		return 0;
 	}


### PR DESCRIPTION
Implement joypad input, passing in the SDL Keyboard State for the relevant keys. I think I should maybe do another pass on this later just to make sure its not overengineered. I'm using two separate variables for each type of input, and then writing to the memory location switches which one a separate pointer points to. A read of the memory location simply reads the dereferenced pointer, so it will get the correct variable depending on the last write.

I have an off state variable that doesn't change and is always all 1s. I'm not quite sure the behaviour of writing 0x0011 0000 to the memory location, since that should deselect both options. I'm assuming it means neither should be used.