### PR TITLE
Implement MBC1 and MBC3

### DIFF
--- a/dmg-emu.vcxproj
+++ b/dmg-emu.vcxproj
@@ -19,6 +19,9 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\MBC.cpp" />
+    <ClCompile Include="src\MBC0.cpp" />
+    <ClCompile Include="src\MBC1.cpp" />
     <ClCompile Include="src\DMG.cpp" />
     <ClCompile Include="src\Cartridge.cpp" />
     <ClCompile Include="src\PPU.cpp" />
@@ -27,6 +30,9 @@
     <ClCompile Include="src\main.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\MBC.h" />
+    <ClInclude Include="src\MBC0.h" />
+    <ClInclude Include="src\MBC1.h" />
     <ClInclude Include="src\DMG.h" />
     <ClInclude Include="src\Cartridge.h" />
     <ClInclude Include="src\PPU.h" />

--- a/dmg-emu.vcxproj
+++ b/dmg-emu.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="src\MBC1.cpp" />
     <ClCompile Include="src\DMG.cpp" />
     <ClCompile Include="src\Cartridge.cpp" />
+    <ClCompile Include="src\MBC3.cpp" />
     <ClCompile Include="src\PPU.cpp" />
     <ClCompile Include="src\MMU.cpp" />
     <ClCompile Include="src\CPU.cpp" />
@@ -35,6 +36,7 @@
     <ClInclude Include="src\MBC1.h" />
     <ClInclude Include="src\DMG.h" />
     <ClInclude Include="src\Cartridge.h" />
+    <ClInclude Include="src\MBC3.h" />
     <ClInclude Include="src\PPU.h" />
     <ClInclude Include="src\MMU.h" />
     <ClInclude Include="src\CPU.h" />

--- a/dmg-emu.vcxproj
+++ b/dmg-emu.vcxproj
@@ -19,7 +19,6 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\MBC.cpp" />
     <ClCompile Include="src\MBC0.cpp" />
     <ClCompile Include="src\MBC1.cpp" />
     <ClCompile Include="src\DMG.cpp" />

--- a/dmg-emu.vcxproj.filters
+++ b/dmg-emu.vcxproj.filters
@@ -33,6 +33,15 @@
     <ClCompile Include="src\DMG.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\MBC.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\MBC1.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\MBC0.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\CPU.h">
@@ -51,6 +60,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\Util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\MBC1.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\MBC.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\MBC0.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/dmg-emu.vcxproj.filters
+++ b/dmg-emu.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="src\MBC0.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\MBC3.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\CPU.h">
@@ -69,6 +72,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\MBC0.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\MBC3.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/dmg-emu.vcxproj.filters
+++ b/dmg-emu.vcxproj.filters
@@ -33,9 +33,6 @@
     <ClCompile Include="src\DMG.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\MBC.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="src\MBC1.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -51,10 +51,10 @@ Cartridge::Cartridge(const std::string& fileName) {
 		if (header.mbcType == 0x00) {
 			mbc = std::make_shared<MBC0>();
 		}
-		else if (header.mbcType >= 0x01 || header.mbcType <= 0x05) {
+		else if (header.mbcType >= 0x01 && header.mbcType <= 0x05) {
 			mbc = std::make_shared<MBC1>();
 		}
-		else if (header.mbcType >= 0x0F || header.mbcType <= 0x13) {
+		else if (header.mbcType >= 0x0F && header.mbcType <= 0x13) {
 			mbc = std::make_shared<MBC3>();
 		}
 	}

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -51,8 +51,11 @@ Cartridge::Cartridge(const std::string& fileName) {
 		if (header.mbcType == 0x00) {
 			mbc = std::make_shared<MBC0>();
 		}
-		else if (header.mbcType == 0x01) {
+		else if (header.mbcType >= 0x01 || header.mbcType <= 0x05) {
 			mbc = std::make_shared<MBC1>();
+		}
+		else if (header.mbcType >= 0x0F || header.mbcType <= 0x13) {
+			mbc = std::make_shared<MBC3>();
 		}
 	}
 	else {
@@ -63,8 +66,8 @@ Cartridge::Cartridge(const std::string& fileName) {
 Cartridge::~Cartridge() {
 }
 
-uint8_t Cartridge::read(uint16_t addr) {
-	uint32_t mappedAddr = mbc->mapAddr(addr);
+uint8_t Cartridge::readRom(uint16_t addr) {
+	uint32_t mappedAddr = mbc->mapRomAddr(addr);
 	if (mappedAddr == 0xFFFFFFFF) {
 		return 0xFF;
 	}
@@ -72,13 +75,22 @@ uint8_t Cartridge::read(uint16_t addr) {
 	return rom[mappedAddr];
 }
 
-void Cartridge::write(uint16_t addr, uint8_t data) {
+uint8_t Cartridge::readRam(uint16_t addr) {
+	uint32_t mappedAddr = mbc->mapRamAddr(addr);
+	if (mappedAddr == 0xFFFFFFFF) {
+		return 0xFF;
+	}
+
+	return ram[mappedAddr];
+}
+
+void Cartridge::writeRam(uint16_t addr, uint8_t data) {
 	if (ramSize == 0) {
 		return;
 	}
 
 	// Only external ram is writable, and only if ram is enabled
-	uint32_t mappedAddr = mbc->mapAddr(addr);
+	uint32_t mappedAddr = mbc->mapRamAddr(addr);
 	if (mappedAddr == 0xFFFFFFFF) {
 		return;
 	}

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -18,10 +18,6 @@ Cartridge::Cartridge(const std::string& fileName) {
 		ifs.seekg(0x147, ifs.beg);
 		ifs.read((char*)&header, 3);
 
-		printf("0x%02x \n", header.mbcType);
-		printf("0x%02x \n", header.romSize);
-		printf("0x%02x \n", header.ramSize);
-
 		// Resize rom to the correct size
 		romBanks = 2 << header.romSize;
 		romSize = (16 * 1024) * romBanks;
@@ -57,6 +53,9 @@ Cartridge::Cartridge(const std::string& fileName) {
 		else if (header.mbcType >= 0x0F && header.mbcType <= 0x13) {
 			mbc = std::make_shared<MBC3>();
 		}
+		else {
+			printf("MBC not implemented");
+		}
 	}
 	else {
 		printf("Error loading rom");
@@ -89,7 +88,6 @@ void Cartridge::writeRam(uint16_t addr, uint8_t data) {
 		return;
 	}
 
-	// Only external ram is writable, and only if ram is enabled
 	uint32_t mappedAddr = mbc->mapRamAddr(addr);
 	if (mappedAddr == 0xFFFFFFFF) {
 		return;

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -2,21 +2,91 @@
 
 #include "Cartridge.h"
 
-
 Cartridge::Cartridge(const std::string& fileName) {	
+	// Read header to determine MBC type and size
+	struct Header {
+		uint8_t mbcType;
+		uint8_t romSize;
+		uint8_t ramSize;
+	} header;
+	
 	// Load file into rom array
 	std::ifstream ifs;
 	ifs.open(fileName, std::ifstream::binary);
 	if (ifs.is_open()) {
-		ifs.read((char*)rom, 32 * 1024);
+		// Read header
+		ifs.seekg(0x147, ifs.beg);
+		ifs.read((char*)&header, 3);
+
+		printf("0x%02x \n", header.mbcType);
+		printf("0x%02x \n", header.romSize);
+		printf("0x%02x \n", header.ramSize);
+
+		// Resize rom to the correct size
+		romBanks = 2 << header.romSize;
+		romSize = (16 * 1024) * romBanks;
+		rom.resize(romSize);
+
+		// Resize ram to the correct size
+		if (header.ramSize == 0x02) {
+			ramBanks = 1;
+		}
+		else if (header.ramSize == 0x03) {
+			ramBanks = 4;
+		}
+		else if (header.ramSize == 0x04) {
+			ramBanks = 16;
+		}
+		else if (header.ramSize == 0x05) {
+			ramBanks = 8;
+		}
+		ramSize = 8 * 1024 * ramBanks;
+		ram.resize(ramSize);
+		
+
+		ifs.seekg(0, ifs.beg);
+		ifs.read((char*)rom.data(), romSize);
 		ifs.close();
+
+		if (header.mbcType == 0x00) {
+			mbc = std::make_shared<MBC0>();
+		}
+		else if (header.mbcType == 0x01) {
+			mbc = std::make_shared<MBC1>();
+		}
+	}
+	else {
+		printf("Error loading rom");
 	}
 }
 
 Cartridge::~Cartridge() {
-	delete[] rom;
 }
 
 uint8_t Cartridge::read(uint16_t addr) {
-	return rom[addr];
+	uint32_t mappedAddr = mbc->mapAddr(addr);
+	if (mappedAddr == 0xFFFFFFFF) {
+		return 0xFF;
+	}
+	
+	return rom[mappedAddr];
+}
+
+void Cartridge::write(uint16_t addr, uint8_t data) {
+	if (ramSize == 0) {
+		return;
+	}
+
+	// Only external ram is writable, and only if ram is enabled
+	uint32_t mappedAddr = mbc->mapAddr(addr);
+	if (mappedAddr == 0xFFFFFFFF) {
+		return;
+	}
+
+	ram[mappedAddr] = data;
+}
+
+void Cartridge::setRegister(uint16_t addr, uint8_t data) {
+	// Change the state of the mapper chip to influence future reads
+	mbc->setRegister(addr, data);
 }

--- a/src/Cartridge.h
+++ b/src/Cartridge.h
@@ -5,6 +5,7 @@
 
 #include "MBC0.h"
 #include "MBC1.h"
+#include "MBC3.h"
 
 class Cartridge {
 public:
@@ -12,8 +13,9 @@ public:
 	~Cartridge();
 
 public:
-	uint8_t read(uint16_t addr);
-	void write(uint16_t addr, uint8_t data);
+	uint8_t readRom(uint16_t addr);
+	uint8_t readRam(uint16_t addr);
+	void writeRam(uint16_t addr, uint8_t data);
 	void setRegister(uint16_t addr, uint8_t data);
 
 private:

--- a/src/Cartridge.h
+++ b/src/Cartridge.h
@@ -28,7 +28,5 @@ private:
 	uint8_t romBanks = 2;
 	uint8_t ramBanks = 0;
 
-	//uint8_t header[3] = {};
-
 	std::shared_ptr<MBC> mbc;
 };

--- a/src/Cartridge.h
+++ b/src/Cartridge.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <string>
-#include <array>
+#include <vector>
+
+#include "MBC0.h"
+#include "MBC1.h"
 
 class Cartridge {
 public:
@@ -9,8 +12,21 @@ public:
 	~Cartridge();
 
 public:
-	uint8_t* rom = new uint8_t[32 * 1024];
-
-public:
 	uint8_t read(uint16_t addr);
+	void write(uint16_t addr, uint8_t data);
+	void setRegister(uint16_t addr, uint8_t data);
+
+private:
+	std::vector<uint8_t> rom;
+	std::vector<uint8_t> ram;
+
+	// Initialized to default (no MBC) sizes
+	uint32_t romSize = 32 * 1024;
+	uint32_t ramSize = 0;
+	uint8_t romBanks = 2;
+	uint8_t ramBanks = 0;
+
+	//uint8_t header[3] = {};
+
+	std::shared_ptr<MBC> mbc;
 };

--- a/src/DMG.cpp
+++ b/src/DMG.cpp
@@ -31,7 +31,9 @@ bool DMG::init() {
 	std::string romName = "test-roms/" + test_roms[test_num];
 
 	//romName = "roms/tetris.gb";
-	romName = "roms/tennis.gb";
+	//romName = "roms/tennis.gb";
+	romName = "roms/super-mario-land.gb";
+	//romName = "roms/pokemon-red.gb";
 
 	// Create cartridge
 	cart = std::make_shared<Cartridge>(romName);

--- a/src/DMG.cpp
+++ b/src/DMG.cpp
@@ -31,9 +31,9 @@ bool DMG::init() {
 	std::string romName = "test-roms/" + test_roms[test_num];
 
 	//romName = "roms/tetris.gb";
-	//romName = "roms/tennis.gb";
+	romName = "roms/tennis.gb";
 	//romName = "roms/super-mario-land.gb";
-	romName = "roms/pokemon-red.gb";
+	//romName = "roms/pokemon-red.gb";
 	//romName = "roms/loz-la.gb";
 
 	// Create cartridge

--- a/src/DMG.cpp
+++ b/src/DMG.cpp
@@ -31,9 +31,9 @@ bool DMG::init() {
 	std::string romName = "test-roms/" + test_roms[test_num];
 
 	//romName = "roms/tetris.gb";
-	romName = "roms/tennis.gb";
+	//romName = "roms/tennis.gb";
 	//romName = "roms/super-mario-land.gb";
-	//romName = "roms/pokemon-red.gb";
+	romName = "roms/pokemon-red.gb";
 	//romName = "roms/loz-la.gb";
 
 	// Create cartridge

--- a/src/DMG.cpp
+++ b/src/DMG.cpp
@@ -9,32 +9,24 @@ DMG::DMG()
 	, ppu(&mmu) {}
 
 bool DMG::init() {
-	// Passing tests 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, instr_timing
-	size_t test_num = 12;
-
-	// Get rom name
+	// Test roms
+	size_t testRomNum = 0;
 	std::string test_roms[] = {
 		"cpu_instrs.gb",
-		"01-special.gb",
-		"02-interrupts.gb",
-		"03-op sp,hl.gb",
-		"04-op r,imm.gb",
-		"05-op rp.gb",
-		"06-ld r,r.gb",
-		"07-jr,jp,call,ret,rst.gb",
-		"08-misc instrs.gb",
-		"09-op r,r.gb",
-		"10-bit ops.gb",
-		"11-op a,(hl).gb",
 		"instr_timing.gb"
 	};
-	std::string romName = "test-roms/" + test_roms[test_num];
+	std::string testRomName = "test-roms/" + test_roms[testRomNum];
 
-	//romName = "roms/tetris.gb";
-	//romName = "roms/tennis.gb";
-	//romName = "roms/super-mario-land.gb";
-	romName = "roms/pokemon-red.gb";
-	//romName = "roms/loz-la.gb";
+	// Games
+	size_t romNum = 2;
+	std::string roms[] = {
+		"tetris.gb",
+		"tennis.gb",
+		"super-mario-land.gb",
+		"pokemon-red.gb",
+		"loz-la.gb"
+	};
+	std::string romName = "roms/" + roms[romNum];
 
 	// Create cartridge
 	cart = std::make_shared<Cartridge>(romName);
@@ -42,9 +34,10 @@ bool DMG::init() {
 
 	std::cout << "Beginning execution of " << romName << std::endl;
 
+	// TODO: Straighten out printing and logging
 	cpu.print_toggle = false;
 	cpu.log_toggle = false;
-	cpu.log_file = "log/l" + std::to_string(test_num) + ".txt";
+	cpu.log_file = "log/l" + std::to_string(testRomNum) + ".txt";
 
 	// Initialize output file
 	if (cpu.log_toggle) {

--- a/src/DMG.cpp
+++ b/src/DMG.cpp
@@ -34,7 +34,7 @@ bool DMG::init() {
 
 	std::cout << "Beginning execution of " << romName << std::endl;
 
-	// TODO: Straighten out printing and logging
+	// TODO: Clean up printing and logging
 	cpu.print_toggle = false;
 	cpu.log_toggle = false;
 	cpu.log_file = "log/l" + std::to_string(testRomNum) + ".txt";

--- a/src/DMG.cpp
+++ b/src/DMG.cpp
@@ -32,8 +32,9 @@ bool DMG::init() {
 
 	//romName = "roms/tetris.gb";
 	//romName = "roms/tennis.gb";
-	romName = "roms/super-mario-land.gb";
-	//romName = "roms/pokemon-red.gb";
+	//romName = "roms/super-mario-land.gb";
+	romName = "roms/pokemon-red.gb";
+	//romName = "roms/loz-la.gb";
 
 	// Create cartridge
 	cart = std::make_shared<Cartridge>(romName);

--- a/src/MBC.h
+++ b/src/MBC.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+class MBC {
+public:
+	virtual uint32_t mapAddr(uint16_t addr) = 0;
+	virtual void setRegister(uint16_t addr, uint8_t data) = 0;
+
+protected:
+	uint8_t romBanks = 0;
+	uint8_t ramBanks = 0;
+	
+	// State of the MBC chip
+	bool ramEnable = 0;
+	uint8_t romBankNumber = 1;		// This defaults to 1, since 0 is treated as 1 for MBC1
+	uint8_t ramBankNumber = 0;
+	uint8_t upperRomBankNumber = 0;
+	uint8_t modeSelect = 0;
+
+	const uint32_t ROM_BANK_SIZE = 16 * 1024;
+	const uint32_t RAM_BANK_SIZE = 8 * 1024;
+};

--- a/src/MBC.h
+++ b/src/MBC.h
@@ -16,7 +16,6 @@ protected:
 	bool ramEnable = 0;
 	uint8_t romBankNumber = 1;		// This defaults to 1, since 0 is treated as 1 for MBC1
 	uint8_t ramBankNumber = 0;
-	uint8_t upperRomBankNumber = 0;
 	uint8_t modeSelect = 0;
 
 	const uint32_t ROM_BANK_SIZE = 16 * 1024;

--- a/src/MBC.h
+++ b/src/MBC.h
@@ -4,7 +4,8 @@
 
 class MBC {
 public:
-	virtual uint32_t mapAddr(uint16_t addr) = 0;
+	virtual uint32_t mapRomAddr(uint16_t addr) = 0;
+	virtual uint32_t mapRamAddr(uint16_t addr) = 0;
 	virtual void setRegister(uint16_t addr, uint8_t data) = 0;
 
 protected:

--- a/src/MBC0.cpp
+++ b/src/MBC0.cpp
@@ -1,11 +1,13 @@
 #include "MBC0.h"
 
-uint32_t MBC0::mapAddr(uint16_t addr) {
-	// Return the mapped address to read from given the current state of the MBC
+uint32_t MBC0::mapRomAddr(uint16_t addr) {
+	return addr;
+}
+
+uint32_t MBC0::mapRamAddr(uint16_t addr) {
 	return addr;
 }
 
 void MBC0::setRegister(uint16_t addr, uint8_t data) {
-	// Modify the MBC state
 	return;
 }

--- a/src/MBC0.cpp
+++ b/src/MBC0.cpp
@@ -1,0 +1,11 @@
+#include "MBC0.h"
+
+uint32_t MBC0::mapAddr(uint16_t addr) {
+	// Return the mapped address to read from given the current state of the MBC
+	return addr;
+}
+
+void MBC0::setRegister(uint16_t addr, uint8_t data) {
+	// Modify the MBC state
+	return;
+}

--- a/src/MBC0.h
+++ b/src/MBC0.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "MBC.h"
+
+class MBC0 : public MBC {
+public:
+	uint32_t mapAddr(uint16_t addr) override;
+	void setRegister(uint16_t addr, uint8_t data) override;
+};

--- a/src/MBC0.h
+++ b/src/MBC0.h
@@ -4,6 +4,7 @@
 
 class MBC0 : public MBC {
 public:
-	uint32_t mapAddr(uint16_t addr) override;
+	uint32_t mapRomAddr(uint16_t addr) override;
+	uint32_t mapRamAddr(uint16_t addr) override;
 	void setRegister(uint16_t addr, uint8_t data) override;
 };

--- a/src/MBC1.cpp
+++ b/src/MBC1.cpp
@@ -1,0 +1,55 @@
+#include "MBC1.h"
+
+uint32_t MBC1::mapAddr(uint16_t addr) {
+	// Return the mapped address to read from given the current state of the MBC
+	if (addr <= 0x3FFF) {
+		return addr;
+	}
+	else if (addr <= 0x7FFF) {
+		return romBankNumber * ROM_BANK_SIZE + (addr - 0x4000);
+	}
+	else if (addr >= 0xA000 && addr <= 0xBFFF) {
+		// Return address of ram to use in the cartridge's ram vector
+		if (ramEnable) {
+			return ramBankNumber * RAM_BANK_SIZE + (addr - 0xA000);
+		}
+		else {
+			return 0xFFFFFFFF;
+		}
+		
+	}
+	else {
+		// This is an error, shouldn't get here
+		return addr;
+	}
+}
+
+void MBC1::setRegister(uint16_t addr, uint8_t data) {
+	// Modify the MBC state
+	if (addr <= 0x1FFF) {
+		// Ram enable
+		data &= 0x0A;
+		ramEnable = data;
+	}
+	else if (addr <= 0x3FFF) {
+		// Rom bank number, bottom 5 bits
+		data &= 0x1F;
+		if (data == 0x00) {
+			data = 0x01;
+		}
+		romBankNumber = data;
+	}
+	else if (addr <= 0x5FFF) {
+		data &= 0x03;
+		if (modeSelect == 0x01) {
+			ramBankNumber = data;
+		}
+		else {
+			upperRomBankNumber = data;
+		}
+	}
+	else if (addr <= 0x7FFF) {
+		data &= 0x01;
+		modeSelect = data;
+	}
+}

--- a/src/MBC1.cpp
+++ b/src/MBC1.cpp
@@ -6,7 +6,11 @@ uint32_t MBC1::mapRomAddr(uint16_t addr) {
 		return addr;
 	}
 	else if (addr <= 0x7FFF) {
-		return romBankNumber * ROM_BANK_SIZE + (addr - 0x4000);
+		uint8_t newRomBankNumber = romBankNumber;
+		if (modeSelect == 0x00) {
+			newRomBankNumber = (upperRomBankNumber << 5) | romBankNumber;
+		}
+		return newRomBankNumber * ROM_BANK_SIZE + (addr - 0x4000);
 	}
 	else {
 		// This is an error, shouldn't get here
@@ -19,7 +23,11 @@ uint32_t MBC1::mapRamAddr(uint16_t addr) {
 	if (addr >= 0xA000 && addr <= 0xBFFF) {
 		// Return address of ram to use in the cartridge's ram vector
 		if (ramEnable) {
-			return ramBankNumber * RAM_BANK_SIZE + (addr - 0xA000);
+			uint8_t newRamBankNumber = 0;
+			if (modeSelect == 0x01) {
+				newRamBankNumber = ramBankNumber;
+			}
+			return newRamBankNumber * RAM_BANK_SIZE + (addr - 0xA000);
 		}
 		else {
 			return 0xFFFFFFFF;
@@ -57,6 +65,8 @@ void MBC1::setRegister(uint16_t addr, uint8_t data) {
 	}
 	else if (addr <= 0x7FFF) {
 		data &= 0x01;
+
+		// Calling modeSelect == 0x01 to mean ram bank bits and 0x00 to mean upper rom bank bits
 		modeSelect = data;
 	}
 }

--- a/src/MBC1.cpp
+++ b/src/MBC1.cpp
@@ -1,11 +1,11 @@
 #include "MBC1.h"
 
 uint32_t MBC1::mapRomAddr(uint16_t addr) {
-	// Return the mapped address to read from given the current state of the MBC
 	if (addr <= 0x3FFF) {
 		return addr;
 	}
 	else if (addr <= 0x7FFF) {
+		// Use the upper rom bank number bits if in rom mode
 		uint8_t newRomBankNumber = romBankNumber;
 		if (modeSelect == 0x00) {
 			newRomBankNumber = (upperRomBankNumber << 5) | romBankNumber;
@@ -13,16 +13,16 @@ uint32_t MBC1::mapRomAddr(uint16_t addr) {
 		return newRomBankNumber * ROM_BANK_SIZE + (addr - 0x4000);
 	}
 	else {
-		// This is an error, shouldn't get here
+		// Error
 		return 0xFFFFFFFF;
 	}
 }
 
 uint32_t MBC1::mapRamAddr(uint16_t addr) {
-	// Return the mapped address to read from given the current state of the MBC
+	// TODO: Refactor logic
 	if (addr >= 0xA000 && addr <= 0xBFFF) {
-		// Return address of ram to use in the cartridge's ram vector
 		if (ramEnable) {
+			// Use the ram bank number bits if in ram mode
 			uint8_t newRamBankNumber = 0;
 			if (modeSelect == 0x01) {
 				newRamBankNumber = ramBankNumber;
@@ -34,13 +34,12 @@ uint32_t MBC1::mapRamAddr(uint16_t addr) {
 		}
 	}
 	else {
-		// This is an error, shouldn't get here
+		// Error
 		return 0xFFFFFFFF;
 	}
 }
 
 void MBC1::setRegister(uint16_t addr, uint8_t data) {
-	// Modify the MBC state
 	if (addr <= 0x1FFF) {
 		// Ram enable
 		data &= 0x0A;
@@ -55,6 +54,7 @@ void MBC1::setRegister(uint16_t addr, uint8_t data) {
 		romBankNumber = data;
 	}
 	else if (addr <= 0x5FFF) {
+		// Upper rom number bits or ram number bits, depending on mode
 		data &= 0x03;
 		if (modeSelect == 0x01) {
 			ramBankNumber = data;
@@ -65,8 +65,6 @@ void MBC1::setRegister(uint16_t addr, uint8_t data) {
 	}
 	else if (addr <= 0x7FFF) {
 		data &= 0x01;
-
-		// Calling modeSelect == 0x01 to mean ram bank bits and 0x00 to mean upper rom bank bits
 		modeSelect = data;
 	}
 }

--- a/src/MBC1.cpp
+++ b/src/MBC1.cpp
@@ -19,7 +19,7 @@ uint32_t MBC1::mapRomAddr(uint16_t addr) {
 }
 
 uint32_t MBC1::mapRamAddr(uint16_t addr) {
-	// TODO: Refactor logic
+	// TODO: Do another pass on the logic here
 	if (addr >= 0xA000 && addr <= 0xBFFF) {
 		if (ramEnable) {
 			// Use the ram bank number bits if in ram mode

--- a/src/MBC1.h
+++ b/src/MBC1.h
@@ -7,4 +7,7 @@ public:
 	uint32_t mapRomAddr(uint16_t addr) override;
 	uint32_t mapRamAddr(uint16_t addr) override;
 	void setRegister(uint16_t addr, uint8_t data) override;
+
+private:
+	uint8_t upperRomBankNumber = 0;
 };

--- a/src/MBC1.h
+++ b/src/MBC1.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "MBC.h"
+
+class MBC1 : public MBC {
+public:
+	uint32_t mapAddr(uint16_t addr) override;
+	void setRegister(uint16_t addr, uint8_t data) override;
+};

--- a/src/MBC3.cpp
+++ b/src/MBC3.cpp
@@ -1,6 +1,6 @@
-#include "MBC1.h"
+#include "MBC3.h"
 
-uint32_t MBC1::mapRomAddr(uint16_t addr) {
+uint32_t MBC3::mapRomAddr(uint16_t addr) {
 	// Return the mapped address to read from given the current state of the MBC
 	if (addr <= 0x3FFF) {
 		return addr;
@@ -14,7 +14,7 @@ uint32_t MBC1::mapRomAddr(uint16_t addr) {
 	}
 }
 
-uint32_t MBC1::mapRamAddr(uint16_t addr) {
+uint32_t MBC3::mapRamAddr(uint16_t addr) {
 	// Return the mapped address to read from given the current state of the MBC
 	if (addr >= 0xA000 && addr <= 0xBFFF) {
 		// Return address of ram to use in the cartridge's ram vector
@@ -31,32 +31,32 @@ uint32_t MBC1::mapRamAddr(uint16_t addr) {
 	}
 }
 
-void MBC1::setRegister(uint16_t addr, uint8_t data) {
+void MBC3::setRegister(uint16_t addr, uint8_t data) {
 	// Modify the MBC state
+	// TODO: Implement RTC
 	if (addr <= 0x1FFF) {
 		// Ram enable
 		data &= 0x0A;
 		ramEnable = data;
 	}
 	else if (addr <= 0x3FFF) {
-		// Rom bank number, bottom 5 bits
-		data &= 0x1F;
+		// Rom bank number, bottom 7 bits
+		data &= 0x7F;
 		if (data == 0x00) {
 			data = 0x01;
 		}
 		romBankNumber = data;
 	}
 	else if (addr <= 0x5FFF) {
-		data &= 0x03;
-		if (modeSelect == 0x01) {
+		// ram bank number
+		if (data <= 0x03) {
 			ramBankNumber = data;
 		}
-		else {
-			upperRomBankNumber = data;
+		else if (data >= 0x08 && data <= 0x0C) {
+			// RTC related
 		}
 	}
 	else if (addr <= 0x7FFF) {
-		data &= 0x01;
-		modeSelect = data;
+		// RTC related
 	}
 }

--- a/src/MBC3.cpp
+++ b/src/MBC3.cpp
@@ -19,7 +19,12 @@ uint32_t MBC3::mapRamAddr(uint16_t addr) {
 	if (addr >= 0xA000 && addr <= 0xBFFF) {
 		// Return address of ram to use in the cartridge's ram vector
 		if (ramEnable) {
-			return ramBankNumber * RAM_BANK_SIZE + (addr - 0xA000);
+			if (modeSelect == 0x01) {
+				// RTC
+			}
+			else {
+				return ramBankNumber * RAM_BANK_SIZE + (addr - 0xA000);
+			}
 		}
 		else {
 			return 0xFFFFFFFF;
@@ -51,9 +56,11 @@ void MBC3::setRegister(uint16_t addr, uint8_t data) {
 		// ram bank number
 		if (data <= 0x03) {
 			ramBankNumber = data;
+			modeSelect = 0x00;
 		}
 		else if (data >= 0x08 && data <= 0x0C) {
-			// RTC related
+			// Use modeSelect to choose ram vs rtc
+			modeSelect = 0x01;
 		}
 	}
 	else if (addr <= 0x7FFF) {

--- a/src/MBC3.cpp
+++ b/src/MBC3.cpp
@@ -1,7 +1,6 @@
 #include "MBC3.h"
 
 uint32_t MBC3::mapRomAddr(uint16_t addr) {
-	// Return the mapped address to read from given the current state of the MBC
 	if (addr <= 0x3FFF) {
 		return addr;
 	}
@@ -9,18 +8,17 @@ uint32_t MBC3::mapRomAddr(uint16_t addr) {
 		return romBankNumber * ROM_BANK_SIZE + (addr - 0x4000);
 	}
 	else {
-		// This is an error, shouldn't get here
+		// Error
 		return 0xFFFFFFFF;
 	}
 }
 
 uint32_t MBC3::mapRamAddr(uint16_t addr) {
-	// Return the mapped address to read from given the current state of the MBC
 	if (addr >= 0xA000 && addr <= 0xBFFF) {
-		// Return address of ram to use in the cartridge's ram vector
 		if (ramEnable) {
 			if (modeSelect == 0x01) {
 				// RTC
+				return 0xFFFFFFFF;
 			}
 			else {
 				return ramBankNumber * RAM_BANK_SIZE + (addr - 0xA000);
@@ -31,13 +29,12 @@ uint32_t MBC3::mapRamAddr(uint16_t addr) {
 		}
 	}
 	else {
-		// This is an error, shouldn't get here
+		// Error
 		return 0xFFFFFFFF;
 	}
 }
 
 void MBC3::setRegister(uint16_t addr, uint8_t data) {
-	// Modify the MBC state
 	// TODO: Implement RTC
 	if (addr <= 0x1FFF) {
 		// Ram enable
@@ -53,17 +50,18 @@ void MBC3::setRegister(uint16_t addr, uint8_t data) {
 		romBankNumber = data;
 	}
 	else if (addr <= 0x5FFF) {
-		// ram bank number
+		// Ram bank number or RTC
+		// Use modeSelect to keep track of ram bank number or rtc (0 = ram, 1 = rtc)
 		if (data <= 0x03) {
 			ramBankNumber = data;
 			modeSelect = 0x00;
 		}
 		else if (data >= 0x08 && data <= 0x0C) {
-			// Use modeSelect to choose ram vs rtc
+			// RTC
 			modeSelect = 0x01;
 		}
 	}
 	else if (addr <= 0x7FFF) {
-		// RTC related
+		// RTC
 	}
 }

--- a/src/MBC3.h
+++ b/src/MBC3.h
@@ -2,7 +2,7 @@
 
 #include "MBC.h"
 
-class MBC1 : public MBC {
+class MBC3 : public MBC {
 public:
 	uint32_t mapRomAddr(uint16_t addr) override;
 	uint32_t mapRamAddr(uint16_t addr) override;

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -11,20 +11,19 @@ MMU::~MMU() {
 
 void MMU::write(uint16_t addr, uint8_t data) {
 	if (addr <= 0x7FFF) {
-		// cartridge, invalid to write to.
-		// Passing into cartridge read will change the state of the mbc chip if there is one
+		// Change the state of mbc chip if there is one
 		cart->setRegister(addr, data);
 	}
 	else if (addr >= 0xA000 && addr <= 0xBFFF) {
-		// external ram
+		// External ram
 		cart->writeRam(addr, data);
 	}
 	else if (addr >= 0xE000 && addr <= 0xFDFF) {
-		// echo ram, prohibited
+		// Echo ram, prohibited
 		return;
 	}
 	else if (addr >= 0xFEA0 && addr <= 0xFEFF) {
-		// unusable
+		// Unusable
 		return;
 	}
 	else if (addr == 0xFF00) {
@@ -74,19 +73,19 @@ void MMU::write(uint16_t addr, uint8_t data) {
 
 uint8_t MMU::read(uint16_t addr) {	
 	if (addr <= 0x7FFF) {
-		// cartridge, figures out proper mapping
+		// Cartridge
 		return cart->readRom(addr);
 	}
 	else if (addr >= 0xA000 && addr <= 0xBFFF) {
-		// external ram
+		// External ram
 		return cart->readRam(addr);
 	}
 	else if (addr >= 0xE000 && addr <= 0xFDFF) {
-		// echo ram, prohibited
+		// Echo ram, prohibited
 		return 0xFF;
 	}
 	else if (addr >= 0xFEA0 && addr <= 0xFEFF) {
-		// unusable
+		// Unusable
 		return 0xFF;
 	}
 	else if (addr == 0xFF00) {

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -17,7 +17,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	}
 	else if (addr >= 0xA000 && addr <= 0xBFFF) {
 		// external ram
-		cart->write(addr, data);
+		cart->writeRam(addr, data);
 	}
 	else if (addr >= 0xE000 && addr <= 0xFDFF) {
 		// echo ram, prohibited
@@ -75,11 +75,11 @@ void MMU::write(uint16_t addr, uint8_t data) {
 uint8_t MMU::read(uint16_t addr) {	
 	if (addr <= 0x7FFF) {
 		// cartridge, figures out proper mapping
-		return cart->read(addr);
+		return cart->readRom(addr);
 	}
 	else if (addr >= 0xA000 && addr <= 0xBFFF) {
 		// external ram
-		return cart->read(addr);
+		return cart->readRam(addr);
 	}
 	else if (addr >= 0xE000 && addr <= 0xFDFF) {
 		// echo ram, prohibited

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -181,9 +181,9 @@ void PPU::setObject(
 			uint8_t updatedShift = xFlip ? (7 - i) : i;
 
 			// Update palette based on selected object palette
-			uint32_t paletteIndex = obp[((hi >> updatedShift) << 1 & 0x02) | ((lo >> updatedShift) & 0x01)];
+			uint32_t objectPaletteIndex = ((hi >> updatedShift) << 1 & 0x02) | ((lo >> updatedShift) & 0x01);
 
-			if (paletteIndex != 0) {
+			if (objectPaletteIndex != 0) {
 				// TODO: rework this to be more accurate to the Game Boy's actual operation.
 				// Check against out of bounds updates.
 				// More accurately, the ppu should search for sprites whose y collides with the current scanline,
@@ -193,7 +193,7 @@ void PPU::setObject(
 				// I wouldn't need to render it on the object layer.
 				if ((y + updatedJ < 256) && (x + 7 - i < 256)) {
 					uint16_t bufferIndex = (y + updatedJ) * width + x + 7 - i;
-					buffer[bufferIndex] = palette[paletteIndex];
+					buffer[bufferIndex] = palette[obp[objectPaletteIndex]];
 					
 					// Keep track if the pixel at the particular index is part of an object with a priority bit set to true
 					objectsPriorityBuffer[bufferIndex] = priority;

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -304,7 +304,9 @@ void PPU::updateObjects() {
 	std::fill(objectsBuffer, objectsBuffer + MAP_WIDTH * MAP_HEIGHT, 0);
 
 	// Iterate 4 bytes at a time from 0xFE00 to 0xFE9F
-	for (int i = 0; i < 40; i++) {
+	// Go in reverse order so earlier oam entries overwrite later ones
+	// This will need to change if I implement more accurate sprite drawing
+	for (int i = 40; i > -1; i--) {
 		uint8_t y = mmu->directRead(oamStart + i * 4);
 		uint8_t x = mmu->directRead(oamStart + i * 4 + 1);
 		uint8_t tileIndex = mmu->directRead(oamStart + i * 4 + 2);

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -305,7 +305,6 @@ void PPU::updateObjects() {
 
 	// Iterate 4 bytes at a time from 0xFE00 to 0xFE9F
 	// Go in reverse order so earlier oam entries overwrite later ones
-	// This will need to change if I implement more accurate sprite drawing
 	for (int i = 40; i > -1; i--) {
 		uint8_t y = mmu->directRead(oamStart + i * 4);
 		uint8_t x = mmu->directRead(oamStart + i * 4 + 1);


### PR DESCRIPTION
In this PR I've implemented MBC1 and MBC3, minus the RTC for MBC3. I can run cpu_instrs.gb, Super Mario Land, Pokemon Red, and Link's Awakening. Some MBC details are somewhat untested, so I'll have to look for some MBC test roms and try out more games.

I've also fixed the sprite priority bug in Tennis, where the ball would appear on top of the player. Ordinarily for each line the oam is searched in order and the first match is the sprite that's chosen. Since I'm currently doing it all once per frame, I mimic this by going through the oam backward, so that earlier sprites overwrite later ones.

There was also a bug where sprites would have too much transparency. Any color 0 (white) in a sprite would end up being transparent. This is because I was checking the wrong index. I was checking the palette index (from the obp) rather than the obp index itself.