### PR TITLE
Vita performance improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ log/
 
 # Location of roms
 roms/
+
+# Location of fonts
+fonts/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,7 +30,8 @@
       },
       "environment": {
         "SDL_PATH": "C:/vclib/SDL2-2.0.20",
-        "PATH": "$env{SDL_PATH}/lib/x64;$penv{PATH}"
+        "SDL_TTF_PATH": "C:/vclib/SDL2_ttf-2.20.0",
+        "PATH": "$env{SDL_PATH}/lib/x64;$env{SDL_TTF_PATH}/lib/x64;$penv{PATH}"
       }
     },
     {

--- a/options.txt
+++ b/options.txt
@@ -2,5 +2,4 @@ romPath=roms/super-mario-land.gb
 palette=mgb
 pixelScale=3
 displayFPS=1
-debugMode=0
 logPath=logs/log.txt

--- a/src/APU.cpp
+++ b/src/APU.cpp
@@ -12,6 +12,7 @@ void APU::clock() {
 	
 	// TODO: Consider switching to using the frame sequencer
 
+	updateFrameSequencer();
 	updateControl();
 	
 	updateChannel1();
@@ -73,6 +74,39 @@ void APU::clock() {
 
 	}
 	sampleCounter--;
+}
+
+void APU::updateFrameSequencer() {
+	// Reset all clocks (assume they were consumed, only true for 1 tick)
+	// TODO: Consider moving this out of the hottest loop and only have them reset when
+	// the channels consume them
+	lengthCtrClock = false;
+	sweepClock = false;
+	volEnvClock = false;
+
+	
+	// Step the frame sequencer forward at 512 Hz
+	if (fsCounter == 0) {
+		fsCounter = 2048;
+		
+		// Length counter, step 0, 2, 4, 6
+		if ((fsStep & 0x01) == 0x00) {
+			lengthCtrClock = true;
+		}
+		
+		// Sweep, step 2, 6
+		if ((fsStep & 0x03) == 0x02) {
+			sweepClock = true;
+		}
+
+		// Vol Env, step 7
+		if ((fsStep & 0x07) == 0x07) {
+			volEnvClock = true;
+		}
+		
+		fsStep++;
+	}
+	fsCounter--;
 }
 
 int APU::getPosDifference() {

--- a/src/APU.cpp
+++ b/src/APU.cpp
@@ -233,8 +233,9 @@ void APU::triggerChannel4() {
 	uint8_t shiftAmount = (nr43 & 0xF0) >> 4;
 	uint8_t divisorCode = (nr43 & 0x07);
 	uint8_t divisor = noiseDivisor[divisorCode];
+	//uint8_t divisor = (divisorCode > 0) ? (divisorCode << 4) : 8;
 
-	frequencyCounter4 = divisor << shiftAmount;
+	frequencyCounter4 = (divisor << shiftAmount) >> 2;			// divide by 4 for M-cycles
 
 	shiftRegister = 0xFFFF;
 }
@@ -550,8 +551,9 @@ void APU::updateChannel4() {
 		uint8_t shiftAmount = (nr43 & 0xF0) >> 4;
 		uint8_t divisorCode = (nr43 & 0x07);
 		uint8_t divisor = noiseDivisor[divisorCode];
+		//uint8_t divisor = (divisorCode > 0) ? (divisorCode << 4) : 8;
 
-		frequencyCounter4 = divisor << shiftAmount;
+		frequencyCounter4 = (divisor << shiftAmount) >> 2;
 
 		// Use the inverted first bit as the sample (-1.0f to 1.0f)
 		sample4 = -2.0f * (float)(shiftRegister & 0x01) + 1.0f;

--- a/src/APU.h
+++ b/src/APU.h
@@ -20,6 +20,9 @@ public:
 	void triggerChannel4();
 
 	void updateChannel1Timer(uint8_t data);
+	void updateChannel2Timer(uint8_t data);
+	void updateChannel3Timer(uint8_t data);
+	void updateChannel4Timer(uint8_t data);
 
 private:
 	void updateChannel1();
@@ -30,9 +33,6 @@ private:
 	void updateControl();
 
 	void updateFrameSequencer();
-	void updateChannel1State();
-
-	
 
 private:
 	MMU* mmu = nullptr;
@@ -112,6 +112,12 @@ private:
 	bool lengthCtrClock = false;
 	bool volEnvClock = false;
 	bool sweepClock = false;
+
+	// Various arrays to be indexed
+	uint8_t squareWaveRatio[4] = { 1, 2, 4, 6 };
+	uint8_t waveVolume[4] = { 0, 0x0F, 0x07, 0x03 };		// 0%, 100%, 50%, 25%
+	uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
+
 
 public:
 	// Debug related information

--- a/src/APU.h
+++ b/src/APU.h
@@ -58,55 +58,27 @@ private:
 	uint16_t readPos = 0;
 	uint16_t writePos = 0;
 	
-	// TODO: Simplify apu data
-	
-	// Channel 1 data
-	float buffer1[1024] = {};
-	uint8_t soundOn1 = 0;
-	uint8_t volume1 = 0;
-	float sample1 = 0.0f;
-	
-	uint32_t soundLengthCounter1 = 0;
-	uint32_t sweepCounter1 = 0;
-	uint32_t envelopeCounter1 = 0;
-	uint32_t frequencyCounter1 = 0;
-	uint16_t bufferIndex1 = 0;
-	uint8_t waveIndex1 = 0;
-	
-	// Channel 2 data
-	float buffer2[1024] = {};
-	uint8_t soundOn2 = 0;
-	uint8_t volume2 = 0;
-	float sample2 = 0.0f;
-	
-	uint16_t soundLengthCounter2 = 0;
-	uint32_t envelopeCounter2 = 0;
-	uint32_t frequencyCounter2 = 0;
-	uint16_t bufferIndex2 = 0;
-	uint8_t waveIndex2 = 0;
+	// TODO: Consider switching channel operation to be more object oriented
+	struct channel {
+		float buffer[1024] = {};
+		uint8_t soundOn = 0;
+		uint8_t volume = 0;
+		float sample = 0.0f;
 
-	// Channel 3 data
-	float buffer3[1024] = {};
-	uint8_t soundOn3 = 0;
-	uint8_t volume3 = 0;
-	float sample3 = 0.0f;
-	
-	uint16_t soundLengthCounter3 = 0;
-	uint32_t frequencyCounter3 = 0;
-	uint16_t bufferIndex3 = 0;
-	uint8_t waveIndex3 = 0;
+		uint32_t lengthCounter = 0;
+		uint32_t sweepCounter = 0;
+		uint32_t envelopeCounter = 0;
+		uint32_t frequencyCounter = 0;
+		uint16_t bufferIndex = 0;
+		uint8_t waveIndex = 0;
+	};
 
-	// Channel 4 data
-	float buffer4[1024] = {};
-	uint8_t soundOn4 = 0;
-	uint8_t volume4 = 0;
-	float sample4 = 0.0f;
+	channel channel1;
+	channel channel2;
+	channel channel3;
+	channel channel4;
+
 	uint16_t shiftRegister = 0xFFFF;
-	
-	uint16_t soundLengthCounter4 = 0;
-	uint32_t envelopeCounter4 = 0;
-	uint32_t frequencyCounter4 = 0;
-	uint16_t bufferIndex4 = 0;
 
 	// Frame sequencer state information
 	uint32_t fsCounter = 0;

--- a/src/APU.h
+++ b/src/APU.h
@@ -22,6 +22,8 @@ private:
 
 	void updateControl();
 
+	void updateFrameSequencer();
+
 private:
 	MMU* mmu = nullptr;
 
@@ -93,6 +95,13 @@ private:
 	uint32_t envelopeCounter4 = 0;
 	uint32_t frequencyCounter4 = 0;
 	uint16_t bufferIndex4 = 0;
+
+	// Frame sequencer state information
+	uint32_t fsCounter = 0;
+	uint8_t fsStep = 0;
+	bool lengthCtrClock = false;
+	bool volEnvClock = false;
+	bool sweepClock = false;
 
 public:
 	// Debug related information

--- a/src/APU.h
+++ b/src/APU.h
@@ -58,6 +58,8 @@ private:
 	uint16_t readPos = 0;
 	uint16_t writePos = 0;
 	
+	// TODO: Simplify apu data
+	
 	// Channel 1 data
 	float buffer1[1024] = {};
 	uint8_t soundOn1 = 0;
@@ -117,6 +119,12 @@ private:
 	uint8_t squareWaveRatio[4] = { 1, 2, 4, 6 };
 	uint8_t waveVolume[4] = { 0, 0x0F, 0x07, 0x03 };		// 0%, 100%, 50%, 25%
 	uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
+
+public:
+	uint8_t dacPower1 = 0;
+	uint8_t dacPower2 = 0;
+	uint8_t dacPower3 = 0;
+	uint8_t dacPower4 = 0;
 
 
 public:

--- a/src/APU.h
+++ b/src/APU.h
@@ -14,6 +14,13 @@ public:
 	
 	int getPosDifference();
 
+	void triggerChannel1();
+	void triggerChannel2();
+	void triggerChannel3();
+	void triggerChannel4();
+
+	void updateChannel1Timer(uint8_t data);
+
 private:
 	void updateChannel1();
 	void updateChannel2();
@@ -23,6 +30,9 @@ private:
 	void updateControl();
 
 	void updateFrameSequencer();
+	void updateChannel1State();
+
+	
 
 private:
 	MMU* mmu = nullptr;
@@ -53,8 +63,8 @@ private:
 	uint8_t soundOn1 = 0;
 	uint8_t volume1 = 0;
 	float sample1 = 0.0f;
-
-	uint16_t soundLengthCounter1 = 0;
+	
+	uint32_t soundLengthCounter1 = 0;
 	uint32_t sweepCounter1 = 0;
 	uint32_t envelopeCounter1 = 0;
 	uint32_t frequencyCounter1 = 0;

--- a/src/DMG.cpp
+++ b/src/DMG.cpp
@@ -3,7 +3,7 @@
 #include "DMG.h"
 
 DMG::DMG()
-	: mmu(&cpu)
+	: mmu(&cpu, &apu)
 	, cpu(&mmu)
 	, ppu(&mmu)
 	, apu(&mmu) {}

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -1,9 +1,11 @@
 #include "CPU.h"
+#include "APU.h"
 
 #include "MMU.h"
 
-MMU::MMU(CPU* cpu) {
+MMU::MMU(CPU* cpu, APU* apu) {
 	this->cpu = cpu;
+	this->apu = apu;
 
 	// Set joypad register to high for now
 	memory[0xFF00] = 0xFF;
@@ -47,6 +49,23 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	else if (addr == 0xFF04) {
 		// If the divider is written to, set it to 0
 		cpu->resetDivider();
+	}
+	else if (addr == 0xFF11) {
+		memory[addr] = data;
+
+		// Update the channel 1 length timer
+		data &= 0x3F;
+		apu->updateChannel1Timer(data);
+	}
+	else if (addr == 0xFF14) {
+		memory[addr] = data;
+		
+		// Bit 7 restarts channel 1
+		data >>= 7;
+
+		if (data) {
+			apu->triggerChannel1();
+		}
 	}
 	else if (addr == 0xFF26) {
 		// Bit 7 turns the sound on or off

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -63,6 +63,14 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		break;
 	}
 
+	case 0xFF12: {
+		memory[addr] = data;
+
+		// Update channel 1 dac power
+		apu->dacPower1 = (data & 0xF8);
+		break;
+	}
+
 	case 0xFF14: {
 		memory[addr] = data;
 
@@ -81,6 +89,14 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		break;
 	}
 
+	case 0xFF17: {
+		memory[addr] = data;
+
+		// Update channel 2 dac power
+		apu->dacPower2 = (data & 0xF8);
+		break;
+	}
+
 	case 0xFF19: {
 		memory[addr] = data;
 
@@ -89,6 +105,14 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		if (data) {
 			apu->triggerChannel2();
 		}
+		break;
+	}
+
+	case 0xFF1A: {
+		memory[addr] = data;
+
+		// Update channel 3 dac power
+		apu->dacPower3 = (data & 0x80);
 		break;
 	}
 
@@ -113,6 +137,14 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		memory[addr] = data;
 		data &= 0x3F;
 		apu->updateChannel4Timer(data);
+		break;
+	}
+
+	case 0xFF21: {
+		memory[addr] = data;
+
+		// Update channel 4 dac power
+		apu->dacPower4 = (data & 0xF8);
 		break;
 	}
 

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -68,9 +68,61 @@ void MMU::write(uint16_t addr, uint8_t data) {
 
 		// Bit 7 restarts channel 1
 		data >>= 7;
-
 		if (data) {
 			apu->triggerChannel1();
+		}
+		break;
+	}
+
+	case 0xFF16: {
+		memory[addr] = data;
+		data &= 0x3F;
+		apu->updateChannel2Timer(data);
+		break;
+	}
+
+	case 0xFF19: {
+		memory[addr] = data;
+
+		// Bit 7 restarts channel 2
+		data >>= 7;
+		if (data) {
+			apu->triggerChannel2();
+		}
+		break;
+	}
+
+	case 0xFF1B: {
+		memory[addr] = data;
+		apu->updateChannel3Timer(data);
+		break;
+	}
+
+	case 0xFF1E: {
+		memory[addr] = data;
+
+		// Bit 7 restarts channel 3
+		data >>= 7;
+		if (data) {
+			apu->triggerChannel3();
+		}
+		break;
+	}
+
+	case 0xFF20: {
+		memory[addr] = data;
+		data &= 0x3F;
+		apu->updateChannel4Timer(data);
+		break;
+	}
+
+	case 0xFF23: {
+		memory[addr] = data;
+
+		// Bit 7 restarts channel 4
+		data >>= 7;
+		if (data) {
+			apu->triggerChannel4();
 		}
 		break;
 	}

--- a/src/MMU.h
+++ b/src/MMU.h
@@ -7,15 +7,17 @@
 #include "Cartridge.h"
 
 class CPU;
+class APU;
 
 class MMU {
 public:
-	MMU(CPU* cpu);
+	MMU(CPU* cpu, APU* apu);
 	~MMU();
 
 public:
 	std::shared_ptr<Cartridge> cart;
 	CPU* cpu = nullptr;
+	APU* apu = nullptr;
 
 	// Main memory, bottom half is unused but simplifies addressing
 	uint8_t* memory = new uint8_t[64 * 1024];

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -465,7 +465,7 @@ void PPU::updateScanline() {
 	bgp[2] = (bgpData & 0x30) >> 4;
 	bgp[3] = (bgpData & 0xC0) >> 6;
 
-	// TODO: Investigate why leaving these unneeded reads seems to improve performance by a couple fps on vita
+	// TODO: Investigate why performing these unneeded reads seems to improve performance by a couple fps on vita
 	/*uint8_t scx = mmu->directRead(0xFF43);
 	uint8_t scy = mmu->directRead(0xFF42);
 	

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -129,8 +129,8 @@ void PPU::updateLY() {
 			ly = 0x00;
 			frameComplete = true;
 
-			// Update the tilemaps at the end of every frame
-			updateTileData();
+			// Update the tilemaps and objects at the end of every frame
+			//updateTileData();
 			updateTileMaps();
 			updateObjects();
 		}
@@ -223,6 +223,7 @@ void PPU::setObject(
 	}
 }
 
+// Useful for debugging but not needed for emulation
 void PPU::updateTileData() {
 	uint16_t block0Start = 0x8000;
 	uint16_t block1Start = 0x8800;

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -55,9 +55,6 @@ public:
 	void updateBackgroundScanline(uint32_t* buffer, int* startingIndex);
 	void updateWindowScanline(uint32_t* buffer, int* startingIndex);
 
-	void updateBackgroundTileMap();
-	void updateWindowTileMap();
-
 	bool frameComplete = false;
 
 private:

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -52,8 +52,8 @@ public:
 	uint32_t* getObjectsBuffer();
 
 	uint32_t readPixel(uint16_t index);
-	void updateLCDC();
-	void updateBackgroundScanline(uint32_t* buffer, uint8_t* startingIndex);
+	void updateBackgroundScanline(uint32_t* buffer, int* startingIndex);
+	void updateWindowScanline(uint32_t* buffer, int* startingIndex);
 
 	bool frameComplete = false;
 
@@ -78,6 +78,4 @@ private:
 	uint16_t secondHalfStart = 0x0000;
 	uint16_t backgroundStart = 0x0000;
 	uint16_t windowStart = 0x0000;
-
-	//uint32_t* backgroundBuffer = new uint32_t[168];
 };

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -55,6 +55,9 @@ public:
 	void updateBackgroundScanline(uint32_t* buffer, int* startingIndex);
 	void updateWindowScanline(uint32_t* buffer, int* startingIndex);
 
+	void updateBackgroundTileMap();
+	void updateWindowTileMap();
+
 	bool frameComplete = false;
 
 private:

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -53,6 +53,7 @@ public:
 
 	uint32_t readPixel(uint16_t index);
 	void updateLCDC();
+	void updateBackgroundScanline(uint32_t* buffer, uint8_t* startingIndex);
 
 	bool frameComplete = false;
 
@@ -77,4 +78,6 @@ private:
 	uint16_t secondHalfStart = 0x0000;
 	uint16_t backgroundStart = 0x0000;
 	uint16_t windowStart = 0x0000;
+
+	//uint32_t* backgroundBuffer = new uint32_t[168];
 };

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -46,16 +46,18 @@ public:
 		bool priority);
 
 	uint32_t* getScreenBuffer();
-	uint32_t* getTileDataBuffer();
-	uint32_t* getBackgroundBuffer();
-	uint32_t* getWindowBuffer();
 	uint32_t* getObjectsBuffer();
 
-	uint32_t readPixel(uint16_t index);
 	void updateBackgroundScanline(uint32_t* buffer, int* startingIndex);
 	void updateWindowScanline(uint32_t* buffer, int* startingIndex);
 
 	bool frameComplete = false;
+
+public:
+	// Used for debugging
+	uint32_t* getTileDataBuffer();
+	uint32_t* getBackgroundBuffer();
+	uint32_t* getWindowBuffer();
 
 private:
 	MMU* mmu = nullptr;
@@ -68,9 +70,6 @@ private:
 	uint8_t ly = 0;
 
 	uint32_t* screenBuffer = new uint32_t[util::DMG_WIDTH * util::DMG_HEIGHT];
-	uint32_t* tileDataBuffer = new uint32_t[util::TILE_DATA_WIDTH * util::TILE_DATA_HEIGHT];
-	uint32_t* backgroundBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];
-	uint32_t* windowBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];
 	uint32_t* objectsBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];
 	bool* objectsPriorityBuffer = new bool[util::MAP_WIDTH * util::MAP_HEIGHT];
 
@@ -78,4 +77,10 @@ private:
 	uint16_t secondHalfStart = 0x0000;
 	uint16_t backgroundStart = 0x0000;
 	uint16_t windowStart = 0x0000;
+
+private:
+	// Used for debugging
+	uint32_t* tileDataBuffer = new uint32_t[util::TILE_DATA_WIDTH * util::TILE_DATA_HEIGHT];
+	uint32_t* backgroundBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];
+	uint32_t* windowBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];
 };

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -51,6 +51,9 @@ public:
 	uint32_t* getWindowBuffer();
 	uint32_t* getObjectsBuffer();
 
+	uint32_t readPixel(uint16_t index);
+	void updateLCDC();
+
 	bool frameComplete = false;
 
 private:
@@ -69,4 +72,9 @@ private:
 	uint32_t* windowBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];
 	uint32_t* objectsBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];
 	bool* objectsPriorityBuffer = new bool[util::MAP_WIDTH * util::MAP_HEIGHT];
+
+	uint16_t firstHalfStart = 0x0000;
+	uint16_t secondHalfStart = 0x0000;
+	uint16_t backgroundStart = 0x0000;
+	uint16_t windowStart = 0x0000;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,6 +196,8 @@ public:
 
 				uint64_t secondEnd = SDL_GetPerformanceCounter();
 				float secondElapsed = (secondEnd - secondStart) / (float)SDL_GetPerformanceFrequency();
+
+				onSecond = true;
 			}
 		}
 		return 0;
@@ -218,7 +220,13 @@ public:
 	}
 	
 	int render() {	
-		SDL_RenderClear(renderer);
+		// TODO: When makes the most sense to render the fps counter?
+		// TODO: Figure out a better way to rerender the FPS counter once a second
+		if (onSecond) {
+			SDL_RenderClear(renderer);
+			renderText(uncappedFPS);
+			onSecond = false;
+		}
 		
 		// Process screen texture
 		renderTexture(
@@ -227,10 +235,6 @@ public:
 			srcScreenRect,
 			destScreenRect,
 			util::DMG_WIDTH * util::DMG_HEIGHT);
-
-		
-		// TODO: When makes the most sense to render the fps counter?
-		renderText(uncappedFPS);
 
 		SDL_RenderPresent(renderer);
 
@@ -328,6 +332,7 @@ private:
 
 	std::string uncappedFPS = "0";
 	std::string cappedFPS = "0";
+	bool onSecond = false;
 };
 
 int main(int argc, char **argv) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,8 +119,7 @@ public:
 		const uint8_t* keyboardState = SDL_GetKeyboardState(NULL);
 #endif
 
-		int secondCounter = 0;
-		uint64_t secondStart = 0;
+		int fpsRenderCounter = 0;
 		
 		bool quit = false;
 		while (!quit) {
@@ -159,10 +158,6 @@ public:
 			// Keep track of start time for each frame and every 60 frames
 			uint64_t start = SDL_GetPerformanceCounter();
 
-			if (secondCounter == 0) {
-				secondStart = SDL_GetPerformanceCounter();
-			}
-
 			// Execute one full frame of the Game Boy
 			dmg.tickFrame();
 			
@@ -189,16 +184,12 @@ public:
 				std::cout << cappedFPS << " | " << uncappedFPS << "    \r" << std::flush;
 			}
 			
-			// Keep track of every second
-			secondCounter++;
-			if (secondCounter > 59) {
-				secondCounter = 0;
-
-				uint64_t secondEnd = SDL_GetPerformanceCounter();
-				float secondElapsed = (secondEnd - secondStart) / (float)SDL_GetPerformanceFrequency();
-
-				onSecond = true;
+			// Keep track of counter to render fps at specified rate
+			if (fpsRenderCounter == 0) {
+				fpsRenderCounter = fpsRenderTicks;
+				renderFPS = true;
 			}
+			fpsRenderCounter--;
 		}
 		return 0;
 	}
@@ -222,10 +213,10 @@ public:
 	int render() {	
 		// TODO: When makes the most sense to render the fps counter?
 		// TODO: Figure out a better way to rerender the FPS counter once a second
-		if (onSecond) {
+		if (renderFPS && util::displayFPS) {
 			SDL_RenderClear(renderer);
 			renderText(uncappedFPS);
-			onSecond = false;
+			renderFPS = false;
 		}
 		
 		// Process screen texture
@@ -295,6 +286,7 @@ public:
 			SDL_GameControllerClose(gameController);
 		}
 #endif
+
 		TTF_CloseFont(font);
 
 		TTF_Quit();
@@ -332,7 +324,8 @@ private:
 
 	std::string uncappedFPS = "0";
 	std::string cappedFPS = "0";
-	bool onSecond = false;
+	bool renderFPS = false;
+	int fpsRenderTicks = 30;
 };
 
 int main(int argc, char **argv) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #ifdef VITA
 #include <psp2/kernel/processmgr.h>
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
 #include "debugScreen.h"
 
 #define printf psvDebugScreenPrintf
@@ -325,7 +326,7 @@ private:
 	std::string uncappedFPS = "0";
 	std::string cappedFPS = "0";
 	bool renderFPS = false;
-	int fpsRenderTicks = 30;
+	int fpsRenderTicks = 60;
 };
 
 int main(int argc, char **argv) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,10 +172,10 @@ public:
 			totalElapsed += elapsed;
 
 			// Delay until 16.666 ms have passed
-			/*while (elapsed < 0.016666) {
+			while (elapsed < 0.016666) {
 				end = SDL_GetPerformanceCounter();
 				elapsed = (end - start) / (double)SDL_GetPerformanceFrequency();
-			}*/			
+			}
 			
 			// Render fps at specified rate using the average elapsed time over the last quantity of frames
 			if (fpsRenderCounter == 0) {
@@ -333,7 +333,7 @@ private:
 	DMG dmg;
 
 	bool renderFPS = false;
-	int fpsRenderTicks = 120;
+	int fpsRenderTicks = 30;
 
 	SDL_Surface* textSurface = NULL;
 	SDL_Texture* textTexture = NULL;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,10 +172,10 @@ public:
 			totalElapsed += elapsed;
 
 			// Delay until 16.666 ms have passed
-			while (elapsed < 0.016666) {
+			/*while (elapsed < 0.016666) {
 				end = SDL_GetPerformanceCounter();
 				elapsed = (end - start) / (double)SDL_GetPerformanceFrequency();
-			}			
+			}*/			
 			
 			// Render fps at specified rate using the average elapsed time over the last quantity of frames
 			if (fpsRenderCounter == 0) {
@@ -333,7 +333,7 @@ private:
 	DMG dmg;
 
 	bool renderFPS = false;
-	int fpsRenderTicks = 30;
+	int fpsRenderTicks = 120;
 
 	SDL_Surface* textSurface = NULL;
 	SDL_Texture* textTexture = NULL;

--- a/src/vita/CMakeLists.txt
+++ b/src/vita/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 include("${VITASDK}/share/vita.cmake" REQUIRED)
 
 find_package(SDL2 REQUIRED)
+#find_package(SDL2_ttf REQUIRED)
 
 ## Configuration options for this app
 # Display name (under bubble in LiveArea)
@@ -57,6 +58,10 @@ target_link_libraries(${PROJECT_NAME}
                     # the most common stubs are automatically included.
   SceDisplay_stub   # This used by debugScreenPrintf()
   SDL2::SDL2
+  SDL2_ttf          # SDL2_ttf dependency information found on HENkaku discord
+  freetype
+  png
+  z
 )
 
 ## Create Vita files
@@ -72,4 +77,5 @@ vita_create_vpk(${PROJECT_NAME}.vpk ${VITA_TITLEID} ${PROJECT_NAME}.self
   FILE ${CMAKE_SOURCE_DIR}/sce_sys/livearea/contents/template.xml sce_sys/livearea/contents/template.xml
   FILE ${CMAKE_SOURCE_DIR}/options.txt options.txt
   FILE ${CMAKE_SOURCE_DIR}/roms/super-mario-land.gb roms/super-mario-land.gb
+  FILE ${CMAKE_SOURCE_DIR}/fonts/consola.ttf fonts/consola.ttf
 )

--- a/src/windows/CMakeLists.txt
+++ b/src/windows/CMakeLists.txt
@@ -11,18 +11,34 @@ file(COPY ${CMAKE_SOURCE_DIR}/roms
 	DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+file(COPY ${CMAKE_SOURCE_DIR}/fonts
+	DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+)
+
 # Set up SDL
-set(SDL_INCLUDE_DIRS $ENV{SDL_PATH}/include)
-set(SDL_LIBRARIES $ENV{SDL_PATH}/lib/x64)
+set(SDL_INCLUDE_DIRS
+	$ENV{SDL_PATH}/include
+	$ENV{SDL_TTF_PATH}/include
+)
+set(SDL_LIBRARIES
+	$ENV{SDL_PATH}/lib/x64
+	$ENV{SDL_TTF_PATH}/lib/x64
+)
 
 include_directories(
 	${SDL_INCLUDE_DIRS}
 )
 
-link_directories(${SDL_LIBRARIES})
+link_directories(
+	${SDL_LIBRARIES}
+)
 
 add_executable (${PROJECT_NAME}
 	${SOURCE}
 )
 
-target_link_libraries(${PROJECT_NAME} SDL2 SDL2main)
+target_link_libraries(${PROJECT_NAME}
+	SDL2
+	SDL2main
+	SDL2_ttf
+)


### PR DESCRIPTION
In this PR I've reworked the PPU and APU for performance gains. I also improved the FPS counter so that it displays on Vita using SDL TTF.

For the PPU I tried out a few changes including reading tile data pixel by pixel and reading tile data one scanline at a time. I found reading one scanline at a time had the best performance gains, improving vita fps from 23 to 26. Reading pixel by pixel decreased vita fps from 23 to 20. The unused perf ideas should be saved in a commit in this PR.

For the APU I implemented a global frame sequencer and made sure to minimize the work I was doing (mainly memory reads) when I didn't need the data. I also changed the channel restart function to occur on writing to the restart bit, rather than reading it every M-cycle. I think there's potential for more changes from continually checking memory locations to having the writes intercepted directly.

Overall performance improved from about 23 to 37 fps.

