### PR TITLE
Improve Vita performance to ~60 fps

### DIFF
--- a/src/APU.cpp
+++ b/src/APU.cpp
@@ -11,7 +11,6 @@ void APU::clock() {
 	// Write a new value on every clock tick until the write position is the same as the read position.
 
 	updateFrameSequencer();
-	updateControl();
 	
 	updateChannel1();
 	updateChannel2();
@@ -42,19 +41,32 @@ void APU::clock() {
 		}
 
 		// Mix samples
-		float channels[4] = {
+		/*float channels[4] = {
 			channel1.buffer[channel1.bufferIndex],
 			channel2.buffer[channel2.bufferIndex],
 			channel3.buffer[channel3.bufferIndex],
 			channel4.buffer[channel4.bufferIndex]
+		};*/
+
+		uint8_t channels[4] = {
+			channel1.bufferSample,
+			channel2.bufferSample,
+			channel3.bufferSample,
+			channel4.bufferSample
 		};
 		
-		float mixSO2 = 0.0f;
-		float mixSO1 = 0.0f;
+		//uint8_t mixSO2 = 0;
+		//uint8_t mixSO1 = 0;
+		float mixSO2 = 0;
+		float mixSO1 = 0;
 		for (int i = 0; i < 4; i++) {
 			mixSO2 += channels[i] * selectionSO2[i];
 			mixSO1 += channels[i] * selectionSO1[i];
 		}
+
+		// Convert uint8_t to float (0..16 = -1.0f..1.0f)
+		mixSO2 = 2.0f * mixSO2 / 16.0f - 1.0f;
+		mixSO1 = 2.0f * mixSO1 / 16.0f - 1.0f;
 
 		// TODO: Make this an option in the options text file
 		/*int channel = 1;
@@ -155,7 +167,7 @@ void APU::triggerChannel1() {
 
 	// If DAC is off, the above actions occur but the channel is disabled again (gbdevwiki sound hardware page)
 	// This is already done in the updateChannel functions this should be redundant
-	if (dacPower1 == 0) {
+	if (channel1.dacPower == 0) {
 		channel1.soundOn = 0;
 	}
 }
@@ -179,7 +191,7 @@ void APU::triggerChannel2() {
 
 	channel2.waveIndex = 0;
 
-	if (dacPower2 == 0) {
+	if (channel2.dacPower == 0) {
 		channel2.soundOn = 0;
 	}
 }
@@ -204,7 +216,7 @@ void APU::triggerChannel3() {
 	
 	channel3.waveIndex = 0;
 
-	if (dacPower3 == 0) {
+	if (channel3.dacPower == 0) {
 		channel3.soundOn = 0;
 	}
 }
@@ -233,29 +245,13 @@ void APU::triggerChannel4() {
 
 	shiftRegister = 0xFFFF;
 
-	if (dacPower4 == 0) {
+	if (channel4.dacPower == 0) {
 		channel4.soundOn = 0;
 	}
 }
 
-void APU::updateChannel1Timer(uint8_t data) {
-	channel1.lengthCounter = 64 - data;
-}
-
-void APU::updateChannel2Timer(uint8_t data) {
-	channel2.lengthCounter = 64 - data;
-}
-
-void APU::updateChannel3Timer(uint8_t data) {
-	channel3.lengthCounter = 256 - data;
-}
-
-void APU::updateChannel4Timer(uint8_t data) {
-	channel4.lengthCounter = 64 - data;
-}
-
 void APU::updateChannel1() {
-	if (dacPower1 == 0) {
+	if (channel1.dacPower == 0) {
 		channel1.soundOn = 0;
 	}
 
@@ -373,23 +369,24 @@ void APU::updateChannel1() {
 		uint8_t waveRatio = squareWaveRatio[wavePatternDutyIndex];
 
 		// Update the sample produced in accordance with the wave frequency
-		channel1.sample = (channel1.waveIndex & 0x07) < waveRatio ? -1.0f : 1.0f;
+		channel1.sample = (channel1.waveIndex & 0x07) < waveRatio ? 0 : 16;
 
 		// Letting it just wrap around for now
 		channel1.waveIndex++;
 	}
 	
 	// Fill the buffer every tick
-	channel1.buffer[channel1.bufferIndex] = channel1.soundOn * channel1.volume * channel1.sample;
+	channel1.bufferSample = channel1.soundOn * channel1.volume * channel1.sample;
+	/*channel1.buffer[channel1.bufferIndex] = channel1.soundOn * channel1.volume * channel1.sample;
 
 	channel1.bufferIndex++;
 	if (channel1.bufferIndex > 1023) {
 		channel1.bufferIndex = 0;
-	}
+	}*/
 }
 
 void APU::updateChannel2() {
-	if (dacPower2 == 0) {
+	if (channel2.dacPower == 0) {
 		channel2.soundOn = 0;
 	}
 	
@@ -447,22 +444,23 @@ void APU::updateChannel2() {
 		uint8_t waveRatio = squareWaveRatio[wavePatternDutyIndex];
 
 		// Update the sample produced in accordance with the wave frequency
-		channel2.sample = (channel2.waveIndex & 0x07) < waveRatio ? -1.0f : 1.0f;
+		channel2.sample = (channel2.waveIndex & 0x07) < waveRatio ? 0 : 16;
 
 		channel2.waveIndex++;
 	}
 
 	// Fill the buffer every tick
-	channel2.buffer[channel2.bufferIndex] = channel2.soundOn * channel2.volume * channel2.sample;
+	channel2.bufferSample = channel2.soundOn * channel2.volume * channel2.sample;
+	/*channel2.buffer[channel2.bufferIndex] = channel2.soundOn * channel2.volume * channel2.sample;
 
 	channel2.bufferIndex++;
 	if (channel2.bufferIndex > 1023) {
 		channel2.bufferIndex = 0;
-	}
+	}*/
 }
 
 void APU::updateChannel3() {
-	if (dacPower3 == 0) {
+	if (channel3.dacPower == 0) {
 		channel3.soundOn = 0;
 	}
 
@@ -501,7 +499,7 @@ void APU::updateChannel3() {
 		}
 
 		// Convert the byte into a float from -1.0 to 1.0
-		channel3.sample = 2.0f * float(sampleByte) / 0xF - 1.0f;
+		channel3.sample = sampleByte;
 
 		// Every tick of the frequency counter, read in the next sample
 		channel3.waveIndex++;
@@ -511,16 +509,17 @@ void APU::updateChannel3() {
 	}
 
 	// Fill the buffer every tick
-	channel3.buffer[channel3.bufferIndex] = channel3.soundOn * channel3.volume * channel3.sample;
+	channel3.bufferSample = channel3.soundOn * channel3.volume * channel3.sample;
+	/*channel3.buffer[channel3.bufferIndex] = channel3.soundOn * channel3.volume * channel3.sample;
 
 	channel3.bufferIndex++;
 	if (channel3.bufferIndex > 1023) {
 		channel3.bufferIndex = 0;
-	}
+	}*/
 }
 
 void APU::updateChannel4() {
-	if (dacPower4 == 0) {
+	if (channel4.dacPower == 0) {
 		channel4.soundOn = 0;
 	}
 
@@ -565,18 +564,20 @@ void APU::updateChannel4() {
 	// Frequency counter
 	channel4.frequencyCounter--;
 	if (channel4.frequencyCounter == 0) {
-		uint8_t nr43 = mmu->directRead(0xFF22);
-		uint8_t shiftAmount = (nr43 & 0xF0) >> 4;
-		uint8_t divisorCode = (nr43 & 0x07);
+		//uint8_t nr43 = mmu->directRead(0xFF22);
+		//uint8_t shiftAmount = (nr43 & 0xF0) >> 4;
+		//uint8_t divisorCode = (nr43 & 0x07);
 
 		// TODO: Profile to see if one way is faster
-		uint8_t divisor = noiseDivisor[divisorCode];
+		//uint8_t divisor = noiseDivisor[channel4.divisorCode];
 		//uint8_t divisor = (divisorCode > 0) ? (divisorCode << 4) : 8;
 
-		channel4.frequencyCounter = (divisor << shiftAmount) >> 2;
+		//channel4.frequencyCounter = (channel4.divisor << channel4.shiftAmount) >> 2;
+		channel4.frequencyCounter = channel4.frequencyPeriod;
 
 		// Use the inverted first bit as the sample (-1.0f to 1.0f)
-		channel4.sample = -2.0f * (float)(shiftRegister & 0x01) + 1.0f;
+		//channel4.sample = -2.0f * (float)(shiftRegister & 0x01) + 1.0f;
+		channel4.sample = ((shiftRegister & 0x01) ^ 0x01) << 4;
 
 		// Shift register operation
 		uint16_t result = (shiftRegister & 0x01) ^ ((shiftRegister & 0x02) >> 1);
@@ -585,20 +586,21 @@ void APU::updateChannel4() {
 		shiftRegister &= ~(result << 14); 
 		shiftRegister |= (result << 14);
 
-		uint8_t widthMode = (nr43 & 0x08) >> 3;
-		if (widthMode) {
+		//uint8_t widthMode = (nr43 & 0x08) >> 3;
+		if (channel4.widthMode) {
 			shiftRegister &= ~(1 << 6);
 			shiftRegister |= (result << 6);
 		}
 	}
 	
 	// Fill the buffer every tick
-	channel4.buffer[channel4.bufferIndex] = channel4.soundOn * channel4.volume * channel4.sample;
-
+	channel4.bufferSample = channel4.soundOn * channel4.volume * channel4.sample;
+	/*channel4.buffer[channel4.bufferIndex] = channel4.soundOn * channel4.volume * channel4.sample;
+	
 	channel4.bufferIndex++;
 	if (channel4.bufferIndex > 1023) {
 		channel4.bufferIndex = 0;
-	}	
+	}*/	
 }
 
 void APU::toggleSound(uint8_t data) {
@@ -606,20 +608,3 @@ void APU::toggleSound(uint8_t data) {
 	soundOn = data;
 }
 
-void APU::updateControl() {
-	uint8_t nr50 = mmu->directRead(0xFF24);
-	uint8_t nr51 = mmu->directRead(0xFF25);
-
-	volumeSO2 = (nr50 & 0x70) >> 4;
-	volumeSO1 = (nr50 & 0x07);
-
-	selectionSO2[3] = (nr51 & 0x80) >> 7;
-	selectionSO2[2] = (nr51 & 0x40) >> 6;
-	selectionSO2[1] = (nr51 & 0x20) >> 5;
-	selectionSO2[0] = (nr51 & 0x10) >> 4;
-
-	selectionSO1[3] = (nr51 & 0x08) >> 3;
-	selectionSO1[2] = (nr51 & 0x04) >> 2;
-	selectionSO1[1] = (nr51 & 0x02) >> 1;
-	selectionSO1[0] = (nr51 & 0x01);
-}

--- a/src/APU.cpp
+++ b/src/APU.cpp
@@ -48,7 +48,6 @@ void APU::clock() {
 			return;
 		}
 
-		// Mix samples
 		// TODO: Find a more elegant way to mix these channels
 		uint16_t mixSO2 = channel1.bufferSample * channel1.so2 * channel1.soundOn +
 			channel2.bufferSample * channel2.so2 * channel2.soundOn +
@@ -156,7 +155,6 @@ void APU::triggerChannel1() {
 	channel1.waveIndex = 0;
 
 	// If DAC is off, the above actions occur but the channel is disabled again (gbdevwiki sound hardware page)
-	// This is already done in the updateChannel functions this should be redundant
 	if (channel1.dacPower == 0) {
 		channel1.soundOn = 0;
 	}
@@ -357,6 +355,7 @@ void APU::updateChannel1() {
 		uint8_t waveRatio = squareWaveRatio[wavePatternDutyIndex];
 
 		// Update the sample produced in accordance with the wave frequency
+		// TODO: Evaluate if there's a better way to do this
 		channel1.sample = (channel1.waveIndex & 0x07) < waveRatio ? 0 : 16;
 
 		// Letting it just wrap around for now

--- a/src/APU.h
+++ b/src/APU.h
@@ -47,11 +47,15 @@ private:
 
 	// TODO: Consider switching channel operation to be more object oriented
 	struct Channel {
-		float buffer[1024] = {};
+		uint8_t dacPower = 0;
 		uint8_t soundOn = 0;
-		uint8_t volume = 0;
+		uint8_t bufferSample = 0;
 		uint8_t sample = 0;		// (0 to 16 for -1.0 to 1.0)
-
+		uint8_t volume = 0;
+		
+		uint8_t so2 = 0;
+		uint8_t so1 = 0;
+		
 		uint32_t lengthCounter = 0;
 		uint32_t sweepCounter = 0;
 		uint32_t envelopeCounter = 0;
@@ -59,16 +63,11 @@ private:
 		uint16_t bufferIndex = 0;
 		uint8_t waveIndex = 0;
 
+		// Channel 4 additional data
 		uint8_t shiftAmount = 0;
 		uint8_t divisor = 0;
 		uint8_t widthMode = 0;
-
 		uint32_t frequencyPeriod = 0;
-		uint8_t dacPower = 0;
-		uint8_t bufferSample = 0;
-
-		uint8_t so2 = 0;
-		uint8_t so1 = 0;
 	};
 
 	uint16_t shiftRegister = 0xFFFF;
@@ -83,7 +82,6 @@ private:
 	// Various arrays to be indexed
 	uint8_t squareWaveRatio[4] = { 1, 2, 4, 6 };
 	uint8_t waveVolume[4] = { 0, 0x0F, 0x07, 0x03 };		// 0%, 100%, 50%, 25%
-	//uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
 
 public:
 	Channel channel1;
@@ -94,8 +92,6 @@ public:
 	// Left and right sound output data
 	uint8_t volumeSO2 = 0;
 	uint8_t volumeSO1 = 0;
-	//uint8_t selectionSO2[4] = {};
-	//uint8_t selectionSO1[4] = {};
 
 	uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
 

--- a/src/APU.h
+++ b/src/APU.h
@@ -19,18 +19,11 @@ public:
 	void triggerChannel3();
 	void triggerChannel4();
 
-	void updateChannel1Timer(uint8_t data);
-	void updateChannel2Timer(uint8_t data);
-	void updateChannel3Timer(uint8_t data);
-	void updateChannel4Timer(uint8_t data);
-
 private:
 	void updateChannel1();
 	void updateChannel2();
 	void updateChannel3();
 	void updateChannel4();
-
-	void updateControl();
 
 	void updateFrameSequencer();
 
@@ -49,21 +42,15 @@ private:
 	float volume = 0.001f;
 	uint8_t soundOn = 1;
 
-	// Left and right sound output data
-	uint8_t volumeSO2 = 0;
-	uint8_t volumeSO1 = 0;
-	uint8_t selectionSO2[4] = {};
-	uint8_t selectionSO1[4] = {};
-
 	uint16_t readPos = 0;
 	uint16_t writePos = 0;
-	
+
 	// TODO: Consider switching channel operation to be more object oriented
 	struct channel {
 		float buffer[1024] = {};
 		uint8_t soundOn = 0;
 		uint8_t volume = 0;
-		float sample = 0.0f;
+		uint8_t sample = 0;		// (0 to 16 for -1.0 to 1.0)
 
 		uint32_t lengthCounter = 0;
 		uint32_t sweepCounter = 0;
@@ -71,12 +58,17 @@ private:
 		uint32_t frequencyCounter = 0;
 		uint16_t bufferIndex = 0;
 		uint8_t waveIndex = 0;
-	};
 
-	channel channel1;
-	channel channel2;
-	channel channel3;
-	channel channel4;
+		uint8_t shiftAmount = 0;
+		uint8_t divisor = 0;
+		uint8_t widthMode = 0;
+
+		uint32_t frequencyPeriod = 0;
+
+		uint8_t dacPower = 0;
+
+		uint8_t bufferSample = 0;
+	};
 
 	uint16_t shiftRegister = 0xFFFF;
 
@@ -90,14 +82,21 @@ private:
 	// Various arrays to be indexed
 	uint8_t squareWaveRatio[4] = { 1, 2, 4, 6 };
 	uint8_t waveVolume[4] = { 0, 0x0F, 0x07, 0x03 };		// 0%, 100%, 50%, 25%
-	uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
+	//uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
 
 public:
-	uint8_t dacPower1 = 0;
-	uint8_t dacPower2 = 0;
-	uint8_t dacPower3 = 0;
-	uint8_t dacPower4 = 0;
+	channel channel1;
+	channel channel2;
+	channel channel3;
+	channel channel4;
 
+	// Left and right sound output data
+	uint8_t volumeSO2 = 0;
+	uint8_t volumeSO1 = 0;
+	uint8_t selectionSO2[4] = {};
+	uint8_t selectionSO1[4] = {};
+
+	uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
 
 public:
 	// Debug related information

--- a/src/APU.h
+++ b/src/APU.h
@@ -46,7 +46,7 @@ private:
 	uint16_t writePos = 0;
 
 	// TODO: Consider switching channel operation to be more object oriented
-	struct channel {
+	struct Channel {
 		float buffer[1024] = {};
 		uint8_t soundOn = 0;
 		uint8_t volume = 0;
@@ -85,10 +85,10 @@ private:
 	//uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
 
 public:
-	channel channel1;
-	channel channel2;
-	channel channel3;
-	channel channel4;
+	Channel channel1;
+	Channel channel2;
+	Channel channel3;
+	Channel channel4;
 
 	// Left and right sound output data
 	uint8_t volumeSO2 = 0;

--- a/src/APU.h
+++ b/src/APU.h
@@ -64,10 +64,11 @@ private:
 		uint8_t widthMode = 0;
 
 		uint32_t frequencyPeriod = 0;
-
 		uint8_t dacPower = 0;
-
 		uint8_t bufferSample = 0;
+
+		uint8_t so2 = 0;
+		uint8_t so1 = 0;
 	};
 
 	uint16_t shiftRegister = 0xFFFF;
@@ -93,8 +94,8 @@ public:
 	// Left and right sound output data
 	uint8_t volumeSO2 = 0;
 	uint8_t volumeSO1 = 0;
-	uint8_t selectionSO2[4] = {};
-	uint8_t selectionSO1[4] = {};
+	//uint8_t selectionSO2[4] = {};
+	//uint8_t selectionSO1[4] = {};
 
 	uint8_t noiseDivisor[8] = { 8, 16, 32, 48, 64, 80, 96, 112 };
 

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -407,7 +407,7 @@ void CPU::clock() {
 	// Execute timer function
 	// TODO: when should this be? I think it just needs to be "before" the interrupt handler
 	// so that it catches the overflow before the next instruction occurs.
-	//updateTimer();
+	
 	// Divider
 	// 16384 Hz is every 256 cycles at 4 MHz
 	// Or every 64 cycles at 1 MHz
@@ -423,7 +423,7 @@ void CPU::clock() {
 	// Timer
 	if (timer.on) {
 		timer_clock++;
-		// Divide speeds by 4 to count M-cycles
+	
 		if (timer_clock > timer.speed - 1) {
 			timer_clock = 0;
 
@@ -432,7 +432,6 @@ void CPU::clock() {
 			if (timer.counter == 0) {
 				// Set timer interrupt if overflow occurred
 				mmu->setIF(2, 1);
-				//IF |= (1 << 2);
 
 				// Set the timer counter to the timer modulo if overflow occurred
 				timer.counter = timer.modulo;
@@ -441,20 +440,7 @@ void CPU::clock() {
 	}
 
 	global_cycles++;
-
-	// NOTE: Shouldn't need this anymore now that I have graphics.
-	// Print Blargg test rom output
-	//print_test();
 }
-
-/*void CPU::print_test() {
-	// Print the test results from blargg's test rom
-	if (mmu->read(0xFF02) == 0x81) {
-		char c = mmu->read(0xFF01);
-		printf("%c", c);
-		mmu->write(0xFF02, 0x00);
-	}
-}*/
 
 bool CPU::complete() {
 	return (cycles == 0);
@@ -1589,9 +1575,6 @@ uint8_t CPU::STOP() {
 }
 
 uint8_t CPU::HALT() {	
-	//uint8_t IE = mmu->directRead(0xFFFF);
-	//uint8_t IF = mmu->directRead(0xFF0F);
-	
 	// Keep track if there was an interrupt pending as soon as halt was called
 	initial_pending_interrupt = IE & IF;
 
@@ -2021,9 +2004,6 @@ uint8_t CPU::SWAP() {
 }
 
 uint8_t CPU::interrupt_handler() {
-	//uint8_t IE = mmu->directRead(0xFFFF);
-	//uint8_t IF = mmu->directRead(0xFF0F);
-
 	uint8_t interrupt = IE & IF;
 	uint8_t interrupt_cycles = 5;
 
@@ -2045,7 +2025,6 @@ uint8_t CPU::interrupt_handler() {
 		IF &= ~(1 << 0);
 		IME = 0;
 
-		//mmu->directWrite(0xFF0F, IF);
 		push_pc();
 
 		pc = 0x0040;
@@ -2055,7 +2034,6 @@ uint8_t CPU::interrupt_handler() {
 		IF &= ~(1 << 1);
 		IME = 0;
 
-		//mmu->directWrite(0xFF0F, IF);
 		push_pc();
 
 		pc = 0x0048;
@@ -2065,7 +2043,6 @@ uint8_t CPU::interrupt_handler() {
 		IF &= ~(1 << 2);
 		IME = 0;
 
-		//mmu->directWrite(0xFF0F, IF);
 		push_pc();
 		
 		pc = 0x0050;
@@ -2075,7 +2052,6 @@ uint8_t CPU::interrupt_handler() {
 		IF &= ~(1 << 3);
 		IME = 0;
 
-		//mmu->directWrite(0xFF0F, IF);
 		push_pc();
 		
 		pc = 0x0058;
@@ -2085,7 +2061,6 @@ uint8_t CPU::interrupt_handler() {
 		IF &= ~(1 << 4);
 		IME = 0;
 
-		//mmu->directWrite(0xFF0F, IF);
 		push_pc();
 		
 		pc = 0x0060;
@@ -2103,50 +2078,9 @@ void CPU::resetDivider() {
 	timer.divider = 0;
 }
 
-uint8_t CPU::updateTimer() {
-	// Divider
-	// 16384 Hz is every 256 cycles at 4 MHz
-	// Or every 64 cycles at 1 MHz
-	divider_clock++;
-	if (divider_clock > 63) {
-		divider_clock = 0;
-
-		// Increment divider every 64 cycles
-		// Divider will automatically overflow
-		timer.divider++;
-	}
-
-	// Timer
-	if (!timer.on) {
-		return 0;
-	}
-
-	timer_clock++;
-	// Divide speeds by 4 to count M-cycles
-	if (timer_clock > timer.speed - 1) {
-		timer_clock = 0;
-
-		// Increment timer after correct number of cycles
-		timer.counter++;
-		if (timer.counter == 0) {
-			// Set timer interrupt if overflow occurred
-			mmu->setIF(2, 1);
-			//IF |= (1 << 2);
-
-			// Set the timer counter to the timer modulo if overflow occurred
-			timer.counter = timer.modulo;
-		}
-	}
-
-	return 0;
-}
-
 uint8_t CPU::halt_cycle() {
 	// Cycle that executes when CPU is in halt state
-	// TODO: test halt bug
-
-	//uint8_t IE = mmu->directRead(0xFFFF);
-	//uint8_t IF = mmu->directRead(0xFF0F);
+	// TODO: Test halt bug
 
 	// Early out cpu should remain in halt state, otherwise wake up
 	if (!(IE & IF)) {

--- a/src/CPU.h
+++ b/src/CPU.h
@@ -43,7 +43,7 @@ public:
 		uint8_t modulo = 0x00;
 	};
 	Timer timer;
-	uint16_t timerSpeeds[4] = { 256, 4, 16, 64 };		// { 1024, 16, 64, 256 } divided by 4 for M cycles
+	uint16_t timerSpeeds[4] = { 256, 4, 16, 64 };		// { 1024, 16, 64, 256 } divided by 4 for M-cycles
 
 	// External event functions
 	void clock();

--- a/src/CPU.h
+++ b/src/CPU.h
@@ -33,9 +33,21 @@ public:
 	uint8_t IF = 0x00;			// 0xFF0F
 	uint8_t IE = 0x00;			// 0xFFFF
 
+	// CPU state things for quick access
+	struct Timer {
+		uint8_t divider = 0x00;
+		uint8_t on = 0x00;
+		uint8_t speedIndex = 0x00;
+		uint16_t speed = 0x00;
+		uint8_t counter = 0x00;
+		uint8_t modulo = 0x00;
+	};
+	uint16_t timerSpeeds[4] = { 256, 4, 16, 64 };	// { 1024, 16, 64, 256 } divided by 4 for M cycles
+	Timer timer;
+
 	// External event functions
 	void clock();
-	uint8_t timer();
+	uint8_t updateTimer();
 	uint8_t interrupt_handler();
 	uint8_t halt_cycle();
 	void resetDivider();

--- a/src/CPU.h
+++ b/src/CPU.h
@@ -30,6 +30,8 @@ public:
 
 	// Interrupt flag
 	uint8_t IME = 0x00;
+	uint8_t IF = 0x00;			// 0xFF0F
+	uint8_t IE = 0x00;			// 0xFFFF
 
 	// External event functions
 	void clock();
@@ -106,8 +108,6 @@ private:
 
 	// Facilitate link to mmu
 	MMU* mmu = nullptr;
-	void write(uint16_t addr, uint8_t data);
-	uint8_t read(uint16_t addr);
 
 	struct INSTRUCTION {
 		INSTRUCTION(uint8_t(CPU::* o)(void) = nullptr,

--- a/src/CPU.h
+++ b/src/CPU.h
@@ -33,7 +33,7 @@ public:
 	uint8_t IF = 0x00;			// 0xFF0F
 	uint8_t IE = 0x00;			// 0xFFFF
 
-	// CPU state things for quick access
+	// CPU timer state for quicker access
 	struct Timer {
 		uint8_t divider = 0x00;
 		uint8_t on = 0x00;
@@ -42,12 +42,11 @@ public:
 		uint8_t counter = 0x00;
 		uint8_t modulo = 0x00;
 	};
-	uint16_t timerSpeeds[4] = { 256, 4, 16, 64 };	// { 1024, 16, 64, 256 } divided by 4 for M cycles
 	Timer timer;
+	uint16_t timerSpeeds[4] = { 256, 4, 16, 64 };		// { 1024, 16, 64, 256 } divided by 4 for M cycles
 
 	// External event functions
 	void clock();
-	uint8_t updateTimer();
 	uint8_t interrupt_handler();
 	uint8_t halt_cycle();
 	void resetDivider();

--- a/src/DMG.cpp
+++ b/src/DMG.cpp
@@ -3,7 +3,7 @@
 #include "DMG.h"
 
 DMG::DMG()
-	: mmu(&cpu, &apu)
+	: mmu(&cpu, &ppu, &apu)
 	, cpu(&mmu)
 	, ppu(&mmu)
 	, apu(&mmu) {}

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -54,6 +54,28 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		cpu->resetDivider();
 		break;
 	}
+	case 0xFF05: {
+		// If the divider is written to, set it to 0
+		cpu->timer.counter = data;
+		break;
+	}
+	case 0xFF06: {
+		// If the divider is written to, set it to 0
+		cpu->timer.modulo = data;
+		break;
+	}
+	case 0xFF07: {
+		// If the divider is written to, set it to 0
+		cpu->timer.on = data & 0x04;
+		cpu->timer.speedIndex = data & 0x03;
+		cpu->timer.speed = cpu->timerSpeeds[data & 0x03];
+		break;
+	}
+	case 0xFF0F: {
+		// IF
+		cpu->IF = data;
+		break;
+	}
 	case 0xFF11: {
 		memory[addr] = data;
 
@@ -225,11 +247,6 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		}
 		break;
 	}
-	case 0xFF0F: {
-		// IF
-		cpu->IF = data;
-		break;
-	}
 	case 0xFFFF: {
 		// IE
 		cpu->IE = data;
@@ -258,7 +275,18 @@ uint8_t MMU::read(uint16_t addr) {
 	case 0xFF00: {
 		// Return the int that selectedButtons currently points to based on the previous write
 		return *selectedButtons;
-		break;
+	}
+	case 0xFF04: {
+		return cpu->timer.divider;
+	}
+	case 0xFF05: {
+		return cpu->timer.counter;
+	}
+	case 0xFF06: {
+		return cpu->timer.modulo;
+	}
+	case 0xFF07: {
+		return (cpu->timer.on << 2) | cpu->timer.speedIndex;
 	}
 	case 0xFF0F: {
 		return cpu->IF;

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -55,17 +55,15 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		break;
 	}
 	case 0xFF05: {
-		// If the divider is written to, set it to 0
 		cpu->timer.counter = data;
 		break;
 	}
 	case 0xFF06: {
-		// If the divider is written to, set it to 0
 		cpu->timer.modulo = data;
 		break;
 	}
 	case 0xFF07: {
-		// If the divider is written to, set it to 0
+		// Update timer speed and keep track of speed index in case it is read
 		cpu->timer.on = data & 0x04;
 		cpu->timer.speedIndex = data & 0x03;
 		cpu->timer.speed = cpu->timerSpeeds[data & 0x03];
@@ -88,7 +86,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		memory[addr] = data;
 		apu->channel1.dacPower = (data & 0xF8);
 		
-		// If dac power is off, disable channel 1
+		// If dac power is off, disable channel
 		if (!apu->channel1.dacPower) {
 			apu->channel1.soundOn = 0;
 		}
@@ -96,7 +94,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	}
 	case 0xFF14: {
 		memory[addr] = data;
-		// Bit 7 restarts channel 1
+		// Bit 7 restarts channel
 		if (data & 0x80) {
 			apu->triggerChannel1();
 		}
@@ -111,8 +109,6 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	case 0xFF17: {
 		memory[addr] = data;
 		apu->channel2.dacPower = (data & 0xF8);
-		
-		// If dac power is off, disable channel 2
 		if (!apu->channel2.dacPower) {
 			apu->channel2.soundOn = 0;
 		}
@@ -128,12 +124,9 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	case 0xFF1A: {
 		memory[addr] = data;
 		apu->channel3.dacPower = (data & 0x80);
-
-		// If dac power is off, disable channel 3
 		if (!apu->channel3.dacPower) {
 			apu->channel3.soundOn = 0;
 		}
-
 		break;
 	}
 	case 0xFF1B: {
@@ -157,8 +150,6 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	case 0xFF21: {
 		memory[addr] = data;
 		apu->channel4.dacPower = (data & 0xF8);
-
-		// If dac power is off, disable channel 4
 		if (!apu->channel4.dacPower) {
 			apu->channel4.soundOn = 0;
 		}
@@ -166,9 +157,11 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	}
 	case 0xFF22: {
 		memory[addr] = data;
+		
+		// Update channel 4 frequency period
 		uint8_t shiftAmount = (data & 0xF0) >> 4;
 		uint8_t divisor = apu->noiseDivisor[(data & 0x07)];
-
+		
 		apu->channel4.frequencyPeriod = (divisor << shiftAmount) >> 2;
 		apu->channel4.widthMode = (data & 0x08) >> 3;
 		break;
@@ -198,7 +191,6 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		apu->channel3.so1 = (data & 0x04) >> 2;
 		apu->channel2.so1 = (data & 0x02) >> 1;
 		apu->channel1.so1 = (data & 0x01);
-
 		break;
 	}
 	case 0xFF26: {
@@ -212,7 +204,6 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		apu->channel2.soundOn = data;
 		apu->channel3.soundOn = data;
 		apu->channel4.soundOn = data;
-
 		break;
 	}
 	case 0xFF40: {
@@ -224,7 +215,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	case 0xFF41: {
 		// LCD STAT
 		data &= 0xF8;
-		data |= (memory[addr] & 0x07);		// Bottom 3 bits are read only
+		data |= (memory[addr] & 0x07);		// bottom 3 bits are read only
 
 		memory[addr] = data;
 		ppu->stat = data;
@@ -296,15 +287,12 @@ uint8_t MMU::read(uint16_t addr) {
 		return cpu->IF;
 	}
 	case 0xFF40: {
-		// LCDC
 		return ppu->lcdc;
 	}
 	case 0xFF41: {
-		// STAT
 		return ppu->stat;
 	}
 	case 0xFF44: {
-		// LY
 		return ppu->ly;
 	}
 	case 0xFFFF: {

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -59,7 +59,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 
 		// Update the channel 1 length timer
 		data &= 0x3F;
-		apu->updateChannel1Timer(data);
+		apu->channel1.lengthCounter = 64 - data;
 		break;
 	}
 
@@ -67,7 +67,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		memory[addr] = data;
 
 		// Update channel 1 dac power
-		apu->dacPower1 = (data & 0xF8);
+		apu->channel1.dacPower = (data & 0xF8);
 		break;
 	}
 
@@ -85,7 +85,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	case 0xFF16: {
 		memory[addr] = data;
 		data &= 0x3F;
-		apu->updateChannel2Timer(data);
+		apu->channel2.lengthCounter = 64 - data;
 		break;
 	}
 
@@ -93,7 +93,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		memory[addr] = data;
 
 		// Update channel 2 dac power
-		apu->dacPower2 = (data & 0xF8);
+		apu->channel2.dacPower = (data & 0xF8);
 		break;
 	}
 
@@ -112,13 +112,13 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		memory[addr] = data;
 
 		// Update channel 3 dac power
-		apu->dacPower3 = (data & 0x80);
+		apu->channel3.dacPower = (data & 0x80);
 		break;
 	}
 
 	case 0xFF1B: {
 		memory[addr] = data;
-		apu->updateChannel3Timer(data);
+		apu->channel3.lengthCounter = 256 - data;
 		break;
 	}
 
@@ -136,7 +136,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	case 0xFF20: {
 		memory[addr] = data;
 		data &= 0x3F;
-		apu->updateChannel4Timer(data);
+		apu->channel4.lengthCounter = 64 - data;
 		break;
 	}
 
@@ -144,7 +144,19 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		memory[addr] = data;
 
 		// Update channel 4 dac power
-		apu->dacPower4 = (data & 0xF8);
+		apu->channel4.dacPower = (data & 0xF8);
+		break;
+	}
+
+	case 0xFF22: {
+		memory[addr] = data;
+		//apu->channel4.shiftAmount = (data & 0xF0) >> 4;
+		//apu->channel4.divisor = apu->noiseDivisor[(data & 0x07)];
+		uint8_t shiftAmount = (data & 0xF0) >> 4;
+		uint8_t divisor = apu->noiseDivisor[(data & 0x07)];
+
+		apu->channel4.frequencyPeriod = (divisor << shiftAmount) >> 2;
+		apu->channel4.widthMode = (data & 0x08) >> 3;
 		break;
 	}
 
@@ -156,6 +168,29 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		if (data) {
 			apu->triggerChannel4();
 		}
+		break;
+	}
+
+	case 0xFF24: {
+		memory[addr] = data;
+		apu->volumeSO2 = (data & 0x70) >> 4;
+		apu->volumeSO1 = (data & 0x07);
+		break;
+	}
+
+	case 0xFF25: {
+		memory[addr] = data;
+		
+		apu->selectionSO2[3] = (data & 0x80) >> 7;
+		apu->selectionSO2[2] = (data & 0x40) >> 6;
+		apu->selectionSO2[1] = (data & 0x20) >> 5;
+		apu->selectionSO2[0] = (data & 0x10) >> 4;
+
+		apu->selectionSO1[3] = (data & 0x08) >> 3;
+		apu->selectionSO1[2] = (data & 0x04) >> 2;
+		apu->selectionSO1[1] = (data & 0x02) >> 1;
+		apu->selectionSO1[0] = (data & 0x01);
+
 		break;
 	}
 

--- a/src/MMU.cpp
+++ b/src/MMU.cpp
@@ -86,17 +86,34 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	}
 	case 0xFF12: {
 		memory[addr] = data;
-
-		// Update channel 1 dac power
 		apu->channel1.dacPower = (data & 0xF8);
+		
+		// If dac power is off, disable channel 1
+		if (!apu->channel1.dacPower) {
+			apu->channel1.soundOn = 0;
+		}
 		break;
 	}
+	/*case 0xFF13: {
+		memory[addr] = data;
+		// Update channel 1 frequency lsb
+		uint16_t frequency = 2048 - apu->channel1.frequencyPeriod;
+		frequency &= 0xFF00;
+		frequency |= data;
+
+		apu->channel1.frequencyPeriod = 2048 - frequency;
+	}*/
 	case 0xFF14: {
 		memory[addr] = data;
 
+		// Update channel 1 frequency msb
+		/*uint16_t frequency = 2048 - apu->channel1.frequencyPeriod;
+		frequency &= 0x00FF;
+		frequency |= (data * 0x07) << 8;
+		apu->channel1.frequencyPeriod = 2048 - frequency;*/
+
 		// Bit 7 restarts channel 1
-		data >>= 7;
-		if (data) {
+		if (data & 0x80) {
 			apu->triggerChannel1();
 		}
 		break;
@@ -109,9 +126,12 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	}
 	case 0xFF17: {
 		memory[addr] = data;
-
-		// Update channel 2 dac power
 		apu->channel2.dacPower = (data & 0xF8);
+		
+		// If dac power is off, disable channel 2
+		if (!apu->channel2.dacPower) {
+			apu->channel2.soundOn = 0;
+		}
 		break;
 	}
 	case 0xFF19: {
@@ -126,9 +146,13 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	}
 	case 0xFF1A: {
 		memory[addr] = data;
-
-		// Update channel 3 dac power
 		apu->channel3.dacPower = (data & 0x80);
+
+		// If dac power is off, disable channel 3
+		if (!apu->channel3.dacPower) {
+			apu->channel3.soundOn = 0;
+		}
+
 		break;
 	}
 	case 0xFF1B: {
@@ -154,9 +178,12 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	}
 	case 0xFF21: {
 		memory[addr] = data;
-
-		// Update channel 4 dac power
 		apu->channel4.dacPower = (data & 0xF8);
+
+		// If dac power is off, disable channel 4
+		if (!apu->channel4.dacPower) {
+			apu->channel4.soundOn = 0;
+		}
 		break;
 	}
 	case 0xFF22: {
@@ -189,7 +216,7 @@ void MMU::write(uint16_t addr, uint8_t data) {
 	case 0xFF25: {
 		memory[addr] = data;
 		
-		apu->selectionSO2[3] = (data & 0x80) >> 7;
+		/*apu->selectionSO2[3] = (data & 0x80) >> 7;
 		apu->selectionSO2[2] = (data & 0x40) >> 6;
 		apu->selectionSO2[1] = (data & 0x20) >> 5;
 		apu->selectionSO2[0] = (data & 0x10) >> 4;
@@ -197,7 +224,17 @@ void MMU::write(uint16_t addr, uint8_t data) {
 		apu->selectionSO1[3] = (data & 0x08) >> 3;
 		apu->selectionSO1[2] = (data & 0x04) >> 2;
 		apu->selectionSO1[1] = (data & 0x02) >> 1;
-		apu->selectionSO1[0] = (data & 0x01);
+		apu->selectionSO1[0] = (data & 0x01);*/
+
+		apu->channel4.so2 = (data & 0x80) >> 7;
+		apu->channel3.so2 = (data & 0x40) >> 6;
+		apu->channel2.so2 = (data & 0x20) >> 5;
+		apu->channel1.so2 = (data & 0x10) >> 4;
+
+		apu->channel4.so1 = (data & 0x08) >> 3;
+		apu->channel3.so1 = (data & 0x04) >> 2;
+		apu->channel2.so1 = (data & 0x02) >> 1;
+		apu->channel1.so1 = (data & 0x01);
 
 		break;
 	}

--- a/src/MMU.h
+++ b/src/MMU.h
@@ -7,16 +7,18 @@
 #include "Cartridge.h"
 
 class CPU;
+class PPU;
 class APU;
 
 class MMU {
 public:
-	MMU(CPU* cpu, APU* apu);
+	MMU(CPU* cpu, PPU* ppu, APU* apu);
 	~MMU();
 
 public:
 	std::shared_ptr<Cartridge> cart;
 	CPU* cpu = nullptr;
+	PPU* ppu = nullptr;
 	APU* apu = nullptr;
 
 	// Main memory, bottom half is unused but simplifies addressing

--- a/src/MMU.h
+++ b/src/MMU.h
@@ -31,6 +31,7 @@ public:
 	uint8_t directRead(uint16_t addr);
 
 	void setBit(uint16_t addr, uint8_t pos, uint8_t value);
+	void setIF(uint8_t pos, uint8_t value);
 
 	void insertCartridge(const std::shared_ptr<Cartridge>& cartridge);
 

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -131,7 +131,6 @@ void PPU::clock() {
 		(stat & (1 << 4) && (stat & 0x03) == 1) ||	// VBlank interrupt
 		(stat & (1 << 3) && (stat & 0x03) == 0)) {	// HBlank interrupt
 		mmu->setIF(1, 1);
-		//cpu->IF |= (1 << 2);
 	}
 }
 

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -45,11 +45,6 @@ PPU::~PPU() {
 
 void PPU::clock() {
 	// Update LY
-	// This function calls the screen updating functions as well
-	updateLY();
-}
-
-void PPU::updateLY() {
 	// TODO: does it make sense for the PPU to read random areas of memory other than vram and oam?
 	// First check if screen is off and reset everything if so
 	if (!(lcdc & 0x80)) {

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -82,7 +82,6 @@ void PPU::clock() {
 		stat |= 0x01;
 	}
 	
-	
 	// Increment LY every 456 real clock cycles
 	// Or 114 M-cycles
 	bool incrementLY = false;

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -121,7 +121,8 @@ void PPU::updateLY() {
 		
 		// Set VBLANK interrupt flag when LY is 144
 		if (ly == 144) {
-			mmu->setBit(0xFF0F, 0, 1);;
+			mmu->setIF(0, 1);
+			//cpu->IF |= (1 << 0);
 		}
 
 		// Reset after 154 cycles
@@ -143,7 +144,8 @@ void PPU::updateLY() {
 		(stat & (1 << 5) && (stat & 0x03) == 2) ||	// OAM interrupt (mode 2)
 		(stat & (1 << 4) && (stat & 0x03) == 1) ||	// VBlank interrupt
 		(stat & (1 << 3) && (stat & 0x03) == 0)) {	// HBlank interrupt
-		mmu->setBit(0xFF0F, 1, 1);
+		mmu->setIF(1, 1);
+		//cpu->IF |= (1 << 2);
 	}
 
 	mmu->directWrite(0xFF41, stat);

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -113,7 +113,6 @@ void PPU::clock() {
 		// Set VBLANK interrupt flag when LY is 144
 		if (ly == 144) {
 			mmu->setIF(0, 1);
-			//cpu->IF |= (1 << 0);
 		}
 
 		// Reset after 154 cycles
@@ -122,8 +121,6 @@ void PPU::clock() {
 			frameComplete = true;
 
 			// Update the tilemaps and objects at the end of every frame
-			//updateTileData();
-			//updateTileMaps();
 			updateObjects();
 		}
 	}

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -14,24 +14,10 @@ public:
 
 public:
 	void clock();
-	void updateLY();
 
-	// TODO: Do a pass on function access, I think a lot of these should be private. I think this goes alongside
-	// an update to frameComplete in the aim of keeping the PPU state internal to the PPU.
-
-	void updateTileData();
-	void updateTileMaps();
+private:
 	void updateScanline();
 	void updateObjects();
-
-	void setTile(
-		uint32_t* buffer,
-		uint16_t width,
-		uint16_t start,
-		uint16_t index,
-		uint8_t x,
-		uint8_t y,
-		uint32_t* bgp);
 
 	void setObject(
 		uint32_t* buffer,
@@ -45,23 +31,15 @@ public:
 		bool yFlip,
 		bool priority);
 
-	uint32_t* getScreenBuffer();
-	uint32_t* getObjectsBuffer();
-
 	void updateBackgroundScanline(uint32_t* buffer, int* startingIndex);
 	void updateWindowScanline(uint32_t* buffer, int* startingIndex);
 
+public:
 	bool frameComplete = false;
 
 	uint8_t lcdc = 0x00;
 	uint8_t stat = 0x00;
 	uint8_t ly = 0;
-
-public:
-	// Used for debugging
-	uint32_t* getTileDataBuffer();
-	uint32_t* getBackgroundBuffer();
-	uint32_t* getWindowBuffer();
 
 private:
 	MMU* mmu = nullptr;
@@ -81,8 +59,28 @@ private:
 	uint16_t backgroundStart = 0x0000;
 	uint16_t windowStart = 0x0000;
 
+public:
+	// Used for debugging
+	uint32_t* getScreenBuffer();
+	uint32_t* getObjectsBuffer();
+	uint32_t* getTileDataBuffer();
+	uint32_t* getBackgroundBuffer();
+	uint32_t* getWindowBuffer();
+
 private:
 	// Used for debugging
+	void setTile(
+		uint32_t* buffer,
+		uint16_t width,
+		uint16_t start,
+		uint16_t index,
+		uint8_t x,
+		uint8_t y,
+		uint32_t* bgp);
+
+	void updateTileData();
+	void updateTileMaps();
+
 	uint32_t* tileDataBuffer = new uint32_t[util::TILE_DATA_WIDTH * util::TILE_DATA_HEIGHT];
 	uint32_t* backgroundBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];
 	uint32_t* windowBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -12,7 +12,6 @@ public:
 	PPU(MMU* mmu);
 	~PPU();
 
-public:
 	void clock();
 
 private:

--- a/src/PPU.h
+++ b/src/PPU.h
@@ -53,6 +53,10 @@ public:
 
 	bool frameComplete = false;
 
+	uint8_t lcdc = 0x00;
+	uint8_t stat = 0x00;
+	uint8_t ly = 0;
+
 public:
 	// Used for debugging
 	uint32_t* getTileDataBuffer();
@@ -67,7 +71,6 @@ private:
 	uint32_t obp1[4] = {};
 
 	uint16_t cycle = 0;
-	uint8_t ly = 0;
 
 	uint32_t* screenBuffer = new uint32_t[util::DMG_WIDTH * util::DMG_HEIGHT];
 	uint32_t* objectsBuffer = new uint32_t[util::MAP_WIDTH * util::MAP_HEIGHT];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,8 +155,6 @@ public:
 			dmg.mmu.writeActionButton(3, !keyboardState[SDL_SCANCODE_A]);		// Start
 #endif
 
-			// TODO: Clean up main loop
-
 			// Keep track of start time for each frame and every 60 frames
 			uint64_t start = SDL_GetPerformanceCounter();
 


### PR DESCRIPTION
I finally managed to increase vita performance to around 60 fps in Super Mario Land 1-1. At times it can dip to around ~57 fps, I think when there is more audio to execute but more testing would need to be done.

The performance improvements I've made are as follows:
- IF, IE, STAT, LCDC, LY, cpu timer state variables, and channel 4 frequency period are now set directly when writing to their memory address, rather than being written to Game Boy memory and polled extremely frequently.
- The timer function has been inlined into CPU clock function and the interrupt handler is only called if there's an interrupt, rather than being called every tick and early outing.
- Channels aren't updated if they're disabled, and turning off DAC power directly disables the channel.
- Float calculations for sound mixing are minimized.

For the future, more performance improvements can be made to maintain a more stable 60 fps. As well, many games may not run at 60 fps, I've only tested Super Mario Land 1-1.