### PR TITLE
Add fontPath to options.txt

### DIFF
--- a/options.txt
+++ b/options.txt
@@ -2,4 +2,5 @@ romPath=roms/super-mario-land.gb
 palette=mgb
 pixelScale=3
 displayFPS=1
+fontPath=fonts/consola.ttf
 logPath=logs/log.txt

--- a/options.txt
+++ b/options.txt
@@ -1,6 +1,6 @@
 romPath=roms/super-mario-land.gb
 palette=mgb
 pixelScale=3
-displayFPS=1
+displayFPS=0
 fontPath=fonts/consola.ttf
 logPath=logs/log.txt

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -18,6 +18,7 @@ namespace util {
 		{"pixelScale", "1"},
 		{"displayFPS", "0"},
 		{"debugMode", "0"},
+		{"fontPath", ""},
 		{"logPath", "logs/log.txt"},
 	};
 
@@ -26,6 +27,7 @@ namespace util {
 	int pixelScale = std::stoi(options["pixelScale"]);
 	int displayFPS = std::stoi(options["displayFPS"]);
 	int debugMode = std::stoi(options["debugMode"]);
+	std::string fontPath = options["fontPath"];
 	std::string logPath = options["logPath"];
 }
 
@@ -97,7 +99,15 @@ int util::readOptionsFile() {
 	pixelScale = std::stoi(options["pixelScale"]);
 	displayFPS = std::stoi(options["displayFPS"]);
 	debugMode = std::stoi(options["debugMode"]);
+	fontPath = options["fontPath"];
 	logPath = options["logPath"];
+
+	// Check for fontPath if displayFPS is 1
+	if (displayFPS && fontPath == "") {
+		printf("displayFPS=1 requires fontPath\n");
+		ifs.close();
+		return -1;
+	}
 	
 	ifs.close();
 	return 0;

--- a/src/Util.h
+++ b/src/Util.h
@@ -20,6 +20,7 @@ namespace util {
 	extern int pixelScale;
 	extern int displayFPS;
 	extern int debugMode;
+	extern std::string fontPath;
 	extern std::string logPath;
 
 	extern std::unordered_map<std::string, std::string> options;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,18 +93,19 @@ public:
 			return -1;
 		}
 #endif
+		if (util::displayFPS) {
+			// Init TTF
+			if (TTF_Init() == -1) {
+				std::cout << "SDL_ttf could not initialize. TTF Error: " << TTF_GetError() << std::endl;
+				return -1;
+			}
 
-		// Init TTF
-		if (TTF_Init() == -1) {
-			std::cout << "SDL_ttf could not initialize. TTF Error: " << TTF_GetError() << std::endl;
-			return -1;
-		}
-
-		// Open font
-		font = TTF_OpenFont("fonts/consola.ttf", fontSize);
-		if (font == NULL) {
-			printf("Failed to open font. TTF Error: %s\n", TTF_GetError());
-			return -1;
+			// Open font
+			font = TTF_OpenFont(util::fontPath.c_str(), fontSize);
+			if (font == NULL) {
+				printf("Failed to open font. TTF Error: %s\n", TTF_GetError());
+				return -1;
+			}
 		}
 
 		// Start dmg
@@ -295,7 +296,10 @@ public:
 			textTexture = nullptr;
 		}
 
-		TTF_CloseFont(font);
+		if (font) {
+			TTF_CloseFont(font);
+			font = nullptr;
+		}
 
 		TTF_Quit();
 		
@@ -353,7 +357,15 @@ int main(int argc, char **argv) {
 
 	Demo demo;
 
-	demo.init();
+	if (demo.init() == -1) {
+		printf("Exiting...\n");
+#ifdef VITA
+		sceKernelDelayThread(3 * 1000000);
+		sceKernelExitProcess(0);
+#endif
+		return 1;
+	};
+	
 	demo.execute();
 	demo.close();
 

--- a/src/vita/CMakeLists.txt
+++ b/src/vita/CMakeLists.txt
@@ -76,6 +76,6 @@ vita_create_vpk(${PROJECT_NAME}.vpk ${VITA_TITLEID} ${PROJECT_NAME}.self
   FILE ${CMAKE_SOURCE_DIR}/sce_sys/livearea/contents/startup.png sce_sys/livearea/contents/startup.png
   FILE ${CMAKE_SOURCE_DIR}/sce_sys/livearea/contents/template.xml sce_sys/livearea/contents/template.xml
   FILE ${CMAKE_SOURCE_DIR}/options.txt options.txt
-  FILE ${CMAKE_SOURCE_DIR}/roms/super-mario-land.gb roms/super-mario-land.gb
-  FILE ${CMAKE_SOURCE_DIR}/fonts/consola.ttf fonts/consola.ttf
+  FILE ${CMAKE_SOURCE_DIR}/roms roms
+  FILE ${CMAKE_SOURCE_DIR}/fonts fonts
 )


### PR DESCRIPTION
In this PR I've added a new fontPath field to options.txt to specify the path to a font for the fps display. This is only required if displayFPS=1. If displayFPS=0, no font is required.